### PR TITLE
Remove defer

### DIFF
--- a/file.go
+++ b/file.go
@@ -107,7 +107,7 @@ func AtomicWriteFileAndChange(filename string, contents []byte, change func(*os.
 	if err != nil {
 		return fmt.Errorf("cannot create temp file: %v", err)
 	}
-    defer f.Close()
+	defer f.Close()
 	defer func() {
 		if err != nil {
 			// Don't leave the temp file lying around on error.


### PR DESCRIPTION
On windows, a file open for writing may not be moved. We need to close the file once we are done with it and moving it after.
