### PR TITLE
fix compile failure on windows

### DIFF
--- a/symlink/symlink_posix.go
+++ b/symlink/symlink_posix.go
@@ -1,6 +1,8 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
+// +build linux darwin
+
 package symlink
 
 import (


### PR DESCRIPTION
```
lucky(~/src/github.com/juju/utils/symlink) % env GOOS=linux go list -f '{{ .GoFiles }}'                                                               
[symlink.go symlink_posix.go]
lucky(~/src/github.com/juju/utils/symlink) % env GOOS=windows go list -f '{{ .GoFiles }}'                                                             
[symlink.go symlink_windows.go zsymlink_windows_amd64.go]
```
