### PR TITLE
Changed path.Join() into filepath.Join() in Home()

### DIFF
--- a/home_windows.go
+++ b/home_windows.go
@@ -5,13 +5,12 @@ package utils
 
 import (
 	"os"
-	"path"
 	"path/filepath"
 )
 
 // Home returns the os-specific home path as specified in the environment.
 func Home() string {
-	return path.Join(os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH"))
+	return filepath.Join(os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH"))
 }
 
 // SetHome sets the os-specific home path in the environment.


### PR DESCRIPTION
This used to lead to the creation of paths which were joined down the middle with a / and caused bogus pathnames to be returned...now Home() will return an appropriate Windows-specific path featuring only \'s.
