### PR TITLE
Add path package

### DIFF
--- a/path/path.go
+++ b/path/path.go
@@ -1,0 +1,12 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// +build !windows
+
+package path
+
+// GetLongPathAsString returns a string representation of a long path.
+func GetLongPathAsString(path string) (string, error) {
+	return path, nil
+}

--- a/path/path_windows.go
+++ b/path/path_windows.go
@@ -1,0 +1,43 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package path
+
+import (
+	"syscall"
+)
+
+// getLongPath converts short style paths (c:\Progra~1\foo) to full
+// long paths.
+func getLongPath(path string) ([]uint16, error) {
+	pathp, err := syscall.UTF16FromString(path)
+	if err != nil {
+		return nil, err
+	}
+
+	longp := pathp
+	n, err := syscall.GetLongPathName(&pathp[0], &longp[0], uint32(len(longp)))
+	if err != nil {
+		return nil, err
+	}
+	if n > uint32(len(longp)) {
+		longp = make([]uint16, n)
+		n, err = syscall.GetLongPathName(&pathp[0], &longp[0], uint32(len(longp)))
+		if err != nil {
+			return nil, err
+		}
+	}
+	longp = longp[:n]
+
+	return longp, nil
+}
+
+// GetLongPathAsString returns a string representation of a long path.
+func GetLongPathAsString(path string) (string, error) {
+	longp, err := getLongPath(path)
+	if err != nil {
+		return "", err
+	}
+	return syscall.UTF16ToString(longp), nil
+}

--- a/path/path_windows_test.go
+++ b/path/path_windows_test.go
@@ -1,0 +1,29 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package path_test
+
+import (
+	"testing"
+
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/utils/path"
+)
+
+type PathUtilsSuite struct{}
+
+var _ = gc.Suite(&PathUtilsSuite{})
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}
+
+func (*PathUtilsSuite) TestLongPath(c *gc.C) {
+	programFiles := `C:\PROGRA~1`
+	longProg := `C:\Program Files`
+	target, err := path.GetLongPathAsString(programFiles)
+	c.Assert(err, gc.IsNil)
+	c.Assert(target, gc.Equals, longProg)
+}

--- a/symlink/export_test.go
+++ b/symlink/export_test.go
@@ -1,8 +1,0 @@
-// Copyright 2014 Cloudbase Solutions SRL
-// Licensed under the LGPLv3, see LICENCE file for details.
-
-package symlink
-
-var (
-	GetLongPathAsString = getLongPathAsString
-)

--- a/symlink/symlink_posix.go
+++ b/symlink/symlink_posix.go
@@ -18,9 +18,3 @@ func New(oldname, newname string) error {
 func Read(link string) (string, error) {
 	return os.Readlink(link)
 }
-
-// getLongPathAsString does nothing on linux. Its here for compatibillity
-// with the windows implementation
-func getLongPathAsString(path string) (string, error) {
-	return path, nil
-}

--- a/symlink/symlink_test.go
+++ b/symlink/symlink_test.go
@@ -10,6 +10,7 @@ import (
 
 	gc "launchpad.net/gocheck"
 
+	"github.com/juju/utils/path"
 	"github.com/juju/utils/symlink"
 )
 
@@ -22,9 +23,9 @@ func Test(t *testing.T) {
 }
 
 func (*SymlinkSuite) TestReplace(c *gc.C) {
-	target, err := symlink.GetLongPathAsString(c.MkDir())
+	target, err := path.GetLongPathAsString(c.MkDir())
 	c.Assert(err, gc.IsNil)
-	target_second, err := symlink.GetLongPathAsString(c.MkDir())
+	target_second, err := path.GetLongPathAsString(c.MkDir())
 	c.Assert(err, gc.IsNil)
 	link := filepath.Join(target, "link")
 

--- a/symlink/symlink_windows_test.go
+++ b/symlink/symlink_windows_test.go
@@ -11,19 +11,12 @@ import (
 
 	gc "launchpad.net/gocheck"
 
+	"github.com/juju/utils/path"
 	"github.com/juju/utils/symlink"
 )
 
-func (*SymlinkSuite) TestLongPath(c *gc.C) {
-	programFiles := `C:\PROGRA~1`
-	longProg := `C:\Program Files`
-	target, err := symlink.GetLongPathAsString(programFiles)
-	c.Assert(err, gc.IsNil)
-	c.Assert(target, gc.Equals, longProg)
-}
-
 func (*SymlinkSuite) TestCreateSymLink(c *gc.C) {
-	target, err := symlink.GetLongPathAsString(c.MkDir())
+	target, err := path.GetLongPathAsString(c.MkDir())
 	c.Assert(err, gc.IsNil)
 
 	link := filepath.Join(target, "link")


### PR DESCRIPTION
For testing purposes we need to get the long path of filesystem paths
on Windows machines. By default non-UTF8 syscalls will return the short path
(Ex:"C:\PROGRA~1" instead of "C:\Program Files"). This package exports
previously private functions used in the symlink package to determine the
long path of a file/directory.