### PR TITLE
Return a concrete metadata type from NewMetadata()

### DIFF
--- a/filestorage/metadata.go
+++ b/filestorage/metadata.go
@@ -51,7 +51,7 @@ type FileMetadata struct {
 // SetID() for that).  Size, Checksum, and ChecksumFormat are left unset
 // (use SetFile() for those).  If no timestamp is provided, the
 // current one is used.
-func NewMetadata(timestamp *time.Time) Metadata {
+func NewMetadata(timestamp *time.Time) *FileMetadata {
 	meta := FileMetadata{}
 	if timestamp == nil {
 		meta.timestamp = time.Now().UTC()


### PR DESCRIPTION
We actually need the concrete type for the backups Metadata (and returning an interface type was originally a misunderstanding on my part anyway).
