### PR TITLE
apt: don't obscure unexpected type errors

### DIFF
--- a/apt/apt_test.go
+++ b/apt/apt_test.go
@@ -5,15 +5,17 @@ package apt_test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
-	"io/ioutil"
 	"path/filepath"
 
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "launchpad.net/gocheck"
 
+	"github.com/juju/utils"
 	"github.com/juju/utils/apt"
 	"github.com/juju/utils/proxy"
 )
@@ -48,16 +50,44 @@ func (s *AptSuite) TestAptGetError(c *gc.C) {
 	state := os.ProcessState{}
 	cmdError := &exec.ExitError{&state}
 
-	cmdExpectedError := fmt.Errorf("apt-get failed: exit status 0")
 	cmdChan := s.HookCommandOutput(&apt.CommandOutput, []byte(expected), error(cmdError))
 	err := apt.GetInstall("foo")
-	c.Assert(err, gc.DeepEquals, cmdExpectedError)
+	c.Assert(err, gc.ErrorMatches, "apt-get failed: exit status 0")
 	cmd := <-cmdChan
 	c.Assert(cmd.Args, gc.DeepEquals, []string{
 		"apt-get", "--option=Dpkg::Options::=--force-confold",
 		"--option=Dpkg::options::=--force-unsafe-io", "--assume-yes", "--quiet",
 		"install", "foo",
 	})
+}
+
+type mockExitStatuser int
+
+func (m mockExitStatuser) ExitStatus() int {
+	return int(m)
+}
+
+func (s *AptSuite) TestAptGetUnexpectedError(c *gc.C) {
+	cmdError := errors.New("whatever")
+	_ = s.HookCommandOutput(&apt.CommandOutput, []byte{}, cmdError)
+	err := apt.GetInstall("test-package")
+	c.Assert(err, gc.ErrorMatches, "apt-get failed: unexpected error type \\*errors\\.Err: whatever")
+}
+
+func (s *AptSuite) TestAptGetRetry(c *gc.C) {
+	var calls int
+	state := os.ProcessState{}
+	cmdError := &exec.ExitError{&state}
+	s.PatchValue(apt.InstallAttemptStrategy, utils.AttemptStrategy{Min: 3})
+	s.PatchValue(apt.ProcessStateSys, func(*os.ProcessState) interface{} {
+		calls++
+		return mockExitStatuser(100 + calls - 1) // 100 is retried
+	})
+
+	_ = s.HookCommandOutput(&apt.CommandOutput, []byte{}, cmdError)
+	err := apt.GetInstall("test-package")
+	c.Check(err, gc.ErrorMatches, "apt-get failed: exit status.*")
+	c.Check(calls, gc.Equals, 2) // only 2 because second exit status != 100
 }
 
 func (s *AptSuite) TestConfigProxyEmpty(c *gc.C) {

--- a/apt/export_test.go
+++ b/apt/export_test.go
@@ -1,0 +1,9 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package apt
+
+var (
+	ProcessStateSys        = &processStateSys
+	InstallAttemptStrategy = &installAttemptStrategy
+)


### PR DESCRIPTION
Errors of unexpected type are being obscured,
and only their type being logged. This change
is to just annotate the error with its type.

We also add some testing of the apt-get install
retry logic. It's still not perfect, but it's
better.
