### PR TITLE
Added build constraint to home_unix test file.

### DIFF
--- a/home_unix_test.go
+++ b/home_unix_test.go
@@ -1,5 +1,6 @@
 // Copyright 2011, 2012, 2013 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
+// +build !windows
 
 package utils_test
 


### PR DESCRIPTION
Without this build constraint, a naming conflict would arise between the suites for the two platforms on Windows as _unix is not recognized by the go compiler as a valid build constraint, resulting in the tests failing to build.
Anyhow, the home_unix tests never had a chance in working on Windows in the first place as home_unix itself has the same build constraint.

Special thanks to @howbazaar for the suggestion.