### PR TITLE
Changed chmod call for windows compatibility

### DIFF
--- a/fs/copy.go
+++ b/fs/copy.go
@@ -62,7 +62,7 @@ func copyFile(src, dst string, mode os.FileMode) error {
 	defer dstf.Close()
 	// Make the actual permissions match the source permissions
 	// even in the presence of umask.
-	if err := dstf.Chmod(mode.Perm()); err != nil {
+	if err := os.Chmod(dstf.Name(), mode.Perm()); err != nil {
 		return err
 	}
 	if _, err := io.Copy(dstf, srcf); err != nil {


### PR DESCRIPTION
Changed the way chmod is called, since os.Chmod works on Windows but file.Chmod does not.
