### PR TITLE
Expose apt errors which lack a process exit code

### DIFF
--- a/apt/apt.go
+++ b/apt/apt.go
@@ -147,7 +147,7 @@ func GetInstall(packages ...string) error {
 		}
 		exitError, ok := err.(*exec.ExitError)
 		if !ok {
-			err = fmt.Errorf("unexpected error type %T", err)
+			// Let the error from CommandOutput fall through
 			break
 		}
 		waitStatus, ok := exitError.ProcessState.Sys().(syscall.WaitStatus)

--- a/apt/apt_test.go
+++ b/apt/apt_test.go
@@ -60,6 +60,21 @@ func (s *AptSuite) TestAptGetError(c *gc.C) {
 	})
 }
 
+func (s *AptSuite) TestAptGetLaunchError(c *gc.C) {
+	cmdError := fmt.Errorf("some strange error")
+	cmdExpectedError := fmt.Errorf("apt-get failed: some strange error")
+	cmdChan := s.HookCommandOutput(&apt.CommandOutput, nil, error(cmdError))
+	err := apt.GetInstall("foo")
+	c.Assert(err, gc.DeepEquals, cmdExpectedError)
+	cmd := <-cmdChan
+	c.Assert(cmd.Args, gc.DeepEquals, []string{
+		"apt-get", "--option=Dpkg::Options::=--force-confold",
+		"--option=Dpkg::options::=--force-unsafe-io", "--assume-yes",
+		"--quiet",
+		"install", "foo",
+	})
+}
+
 func (s *AptSuite) TestConfigProxyEmpty(c *gc.C) {
 	cmdChan := s.HookCommandOutput(&apt.CommandOutput, []byte{}, nil)
 	out, err := apt.ConfigProxy()


### PR DESCRIPTION
Attempting to run apt-get install may fail before the process is
actually launched, and will not get an error type that includes an
exit code. Expose the underlying error string here rather than
masking it with a complaint about the type.
