### PR TITLE
Upcast uptime from syscall

### DIFF
--- a/uptime/uptime_nix.go
+++ b/uptime/uptime_nix.go
@@ -17,5 +17,5 @@ func Uptime() (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return info.Uptime, nil
+	return int64(info.Uptime), nil
 }


### PR DESCRIPTION
On arm and i386 the uptime value is int32 rather than int64,
so upcast to satify the function return value.
