### PR TITLE
jsonhttp: new package

### DIFF
--- a/jsonhttp/jsonhttp.go
+++ b/jsonhttp/jsonhttp.go
@@ -1,0 +1,93 @@
+// The jsonhttp package provides general functions for returning
+// JSON responses to HTTP requests. It is agnostic about
+// the specific form of any returned errors.
+package jsonhttp
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"gopkg.in/errgo.v1"
+)
+
+// ErrorToResponse represents a function that can convert a Go error
+// into a form that can be returned as a JSON body from an HTTP request.
+// The httpStatus value reports the desired HTTP status.
+type ErrorToResponse func(err error) (httpStatus int, errorBody interface{})
+
+// ErrorHandler is like http.Handler except it returns an error
+// which may be returned as the error body of the response.
+// An ErrorHandler function should not itself write to the ResponseWriter
+// if it returns an error.
+type ErrorHandler func(http.ResponseWriter, *http.Request) error
+
+// HandleErrors returns a function that can be used to convert an ErrorHandler
+// into an http.Handler. The given errToResp parameter is used to convert
+// any non-nil error returned by handle to the response in the HTTP body.
+func HandleErrors(errToResp ErrorToResponse) func(handle ErrorHandler) http.Handler {
+	writeError := WriteError(errToResp)
+	return func(handle ErrorHandler) http.Handler {
+		f := func(w http.ResponseWriter, req *http.Request) {
+			if err := handle(w, req); err != nil {
+				writeError(w, err)
+			}
+		}
+		return http.HandlerFunc(f)
+	}
+}
+
+// WriteError returns a function that can be used to write an error to a ResponseWriter
+// and set the HTTP status code. The errToResp parameter is used to determine
+// the actual error value and status to write.
+func WriteError(errToResp ErrorToResponse) func(w http.ResponseWriter, err error) {
+	return func(w http.ResponseWriter, err error) {
+		status, resp := errToResp(err)
+		WriteJSON(w, status, resp)
+	}
+}
+
+// WriteJSON writes the given value to the ResponseWriter
+// and sets the HTTP status to the given code.
+func WriteJSON(w http.ResponseWriter, code int, val interface{}) error {
+	// TODO consider marshalling directly to w using json.NewEncoder.
+	// pro: this will not require a full buffer allocation.
+	// con: if there's an error after the first write, it will be lost.
+	data, err := json.Marshal(val)
+	if err != nil {
+		// TODO(rog) log an error if this fails and lose the
+		// error return, because most callers will need
+		// to do that anyway.
+		return errgo.Mask(err)
+	}
+	w.Header().Set("content-type", "application/json")
+	w.WriteHeader(code)
+	w.Write(data)
+	return nil
+}
+
+// JSONHandler is like http.Handler except that it returns a
+// body (to be converted to JSON) and an error.
+// An ErrorHandler function should not itself write to the
+// ResponseWriter.
+// TODO(rog) remove ResponseWriter argument from function argument.
+// It is redundant (and possibly dangerous) if used in combination with the interface{}
+// return.
+type JSONHandler func(http.ResponseWriter, *http.Request) (interface{}, error)
+
+// HandleJSON returns a function that can be used to convert an JSONHandler
+// into an http.Handler. The given errToResp parameter is used to convert
+// any non-nil error returned by handle to the response in the HTTP body
+// If it returns a nil value, the original error is returned as a JSON string.
+func HandleJSON(errToResp ErrorToResponse) func(handle JSONHandler) http.Handler {
+	handleErrors := HandleErrors(errToResp)
+	return func(handle JSONHandler) http.Handler {
+		f := func(w http.ResponseWriter, req *http.Request) error {
+			val, err := handle(w, req)
+			if err != nil {
+				return errgo.Mask(err, errgo.Any)
+			}
+			return WriteJSON(w, http.StatusOK, val)
+		}
+		return handleErrors(f)
+	}
+}

--- a/jsonhttp/jsonhttp_test.go
+++ b/jsonhttp/jsonhttp_test.go
@@ -1,0 +1,158 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package jsonhttp_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/errgo"
+	"github.com/juju/utils/jsonhttp"
+)
+
+type suite struct{}
+
+var _ = gc.Suite(&suite{})
+
+func (*suite) TestWriteJSON(c *gc.C) {
+	rec := httptest.NewRecorder()
+	type Number struct {
+		N int
+	}
+	err := jsonhttp.WriteJSON(rec, http.StatusTeapot, Number{1234})
+	c.Assert(err, gc.IsNil)
+	c.Assert(rec.Code, gc.Equals, http.StatusTeapot)
+	c.Assert(rec.Body.String(), gc.Equals, `{"N":1234}`)
+	c.Assert(rec.Header().Get("content-type"), gc.Equals, "application/json")
+}
+
+var (
+	errUnauth = errors.New("unauth")
+	errBadReq = errors.New("bad request")
+	errOther  = errors.New("other")
+	errNil    = errors.New("nil result")
+)
+
+type errorResponse struct {
+	Message string
+}
+
+func errorToResponse(err error) (int, interface{}) {
+	resp := &errorResponse{
+		Message: err.Error(),
+	}
+	status := http.StatusInternalServerError
+	switch errgo.Cause(err) {
+	case errUnauth:
+		status = http.StatusUnauthorized
+	case errBadReq:
+		status = http.StatusBadRequest
+	case errNil:
+		return status, nil
+	}
+	return status, &resp
+}
+
+var writeErrorTests = []struct {
+	err          error
+	expectStatus int
+	expectResp   *errorResponse
+}{{
+	err:          errUnauth,
+	expectStatus: http.StatusUnauthorized,
+	expectResp: &errorResponse{
+		Message: errUnauth.Error(),
+	},
+}, {
+	err:          errBadReq,
+	expectStatus: http.StatusBadRequest,
+	expectResp: &errorResponse{
+		Message: errBadReq.Error(),
+	},
+}, {
+	err:          errOther,
+	expectStatus: http.StatusInternalServerError,
+	expectResp: &errorResponse{
+		Message: errOther.Error(),
+	},
+}, {
+	err:          errNil,
+	expectStatus: http.StatusInternalServerError,
+}}
+
+func (s *suite) TestWriteError(c *gc.C) {
+	writeError := jsonhttp.WriteError(errorToResponse)
+	for i, test := range writeErrorTests {
+		c.Logf("%d: %s", i, test.err)
+		rec := httptest.NewRecorder()
+		writeError(rec, test.err)
+		resp := parseErrorResponse(c, rec.Body.Bytes())
+		c.Assert(resp, gc.DeepEquals, test.expectResp)
+		c.Assert(rec.Code, gc.Equals, test.expectStatus)
+	}
+}
+
+func parseErrorResponse(c *gc.C, body []byte) *errorResponse {
+	var errResp *errorResponse
+	err := json.Unmarshal(body, &errResp)
+	c.Assert(err, gc.IsNil)
+	return errResp
+}
+
+func (s *suite) TestHandleErrors(c *gc.C) {
+	handleErrors := jsonhttp.HandleErrors(errorToResponse)
+
+	// Test when handler returns an error.
+	handler := handleErrors(func(http.ResponseWriter, *http.Request) error {
+		return errUnauth
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, new(http.Request))
+	c.Assert(rec.Code, gc.Equals, http.StatusUnauthorized)
+	resp := parseErrorResponse(c, rec.Body.Bytes())
+	c.Assert(resp, gc.DeepEquals, &errorResponse{
+		Message: errUnauth.Error(),
+	})
+
+	// Test when handler returns nil.
+	handler = handleErrors(func(w http.ResponseWriter, _ *http.Request) error {
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte("something"))
+		return nil
+	})
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, new(http.Request))
+	c.Assert(rec.Code, gc.Equals, http.StatusCreated)
+	c.Assert(rec.Body.String(), gc.Equals, "something")
+}
+
+func (s *suite) TestHandleJSON(c *gc.C) {
+	handleJSON := jsonhttp.HandleJSON(errorToResponse)
+
+	// Test when handler returns an error.
+	handler := handleJSON(func(http.ResponseWriter, *http.Request) (interface{}, error) {
+		return nil, errUnauth
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, new(http.Request))
+	resp := parseErrorResponse(c, rec.Body.Bytes())
+	c.Assert(resp, gc.DeepEquals, &errorResponse{
+		Message: errUnauth.Error(),
+	})
+	c.Assert(rec.Code, gc.Equals, http.StatusUnauthorized)
+
+	// Test when handler returns a body.
+	handler = handleJSON(func(w http.ResponseWriter, _ *http.Request) (interface{}, error) {
+		w.WriteHeader(http.StatusCreated)
+		return "something", nil
+	})
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, new(http.Request))
+	c.Assert(rec.Code, gc.Equals, http.StatusCreated)
+	c.Assert(rec.Body.String(), gc.Equals, `"something"`)
+}

--- a/jsonhttp/package_test.go
+++ b/jsonhttp/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package jsonhttp_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
This factors out some functionality from the charm store that makes
it easier to write JSON-returning HTTP handlers, without tying
it to a specific representation of error responses.
