### PR TITLE
update to use gopkg.in/errgo.v1

### DIFF
--- a/filestorage/simple.go
+++ b/filestorage/simple.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/utils"
 )
 

--- a/jsonhttp/jsonhttp.go
+++ b/jsonhttp/jsonhttp.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
 )
 
 // ErrorToResponse represents a function that can convert a Go error

--- a/jsonhttp/jsonhttp_test.go
+++ b/jsonhttp/jsonhttp_test.go
@@ -10,8 +10,8 @@ import (
 	"net/http/httptest"
 
 	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
 
-	"github.com/juju/errgo"
 	"github.com/juju/utils/jsonhttp"
 )
 

--- a/tar/tar_test.go
+++ b/tar/tar_test.go
@@ -16,9 +16,8 @@ import (
 	"strings"
 	stdtesting "testing"
 
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
 func TestPackage(t *stdtesting.T) {

--- a/zip/zip_test.go
+++ b/zip/zip_test.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	ft "github.com/juju/testing/filetesting"
 	gc "gopkg.in/check.v1"
 
-	ft "github.com/juju/testing/filetesting"
 	"github.com/juju/utils/zip"
 )
 


### PR DESCRIPTION
This is the new canonical path for the errgo package.
