### PR TITLE
Fixed http transport for windows compatibility

### DIFF
--- a/file_unix.go
+++ b/file_unix.go
@@ -1,5 +1,6 @@
 // Copyright 2013 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
+
 // +build !windows
 
 package utils
@@ -7,6 +8,7 @@ package utils
 import (
 	"os"
 	"os/user"
+	"strings"
 )
 
 var noSuchUser = `user: unknown user [a-zA-Z0-9]+`
@@ -24,4 +26,12 @@ func homeDir(userName string) (string, error) {
 // those returned by os.Rename.
 func ReplaceFile(source, destination string) error {
 	return os.Rename(source, destination)
+}
+
+// MakeFileURL returns a file URL if a directory is passed in else it does nothing
+func MakeFileURL(in string) string {
+	if strings.HasPrefix(in, "/") {
+		return "file://" + in
+	}
+	return in
 }

--- a/file_windows_test.go
+++ b/file_windows_test.go
@@ -1,0 +1,42 @@
+// Copyright 2013 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// +build windows
+
+package utils_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils"
+)
+
+type windowsFileSuite struct {
+}
+
+var _ = gc.Suite(&windowsFileSuite{})
+
+func (s *windowsFileSuite) TestMakeFileURL(c *gc.C) {
+   var makeFileURLTests = []struct {
+       in string
+       expected string
+   }{{
+       in:       "file://C:\\foo\\baz",
+       expected: "file://\\\\localhost\\C$/foo/baz",
+   }, {
+       in:       "C:\\foo\\baz",
+       expected: "file://\\\\localhost\\C$/foo/baz",
+   }, {
+       in:       "http://foo/baz",
+       expected: "http://foo/baz",
+   }, {
+       in:       "file://\\\\localhost\\C$/foo/baz",
+       expected: "file://\\\\localhost\\C$/foo/baz",
+   }}
+
+   for i, t := range makeFileURLTests {
+       c.Logf("Test %d", i)
+       c.Assert(utils.MakeFileURL(t.in), gc.Equals,t.expected)
+   }
+}


### PR DESCRIPTION
This implements filestorage for windows and will be followed up by another PR in core. For now it only works for C:, but we have no use cases for other drives at the moment.
