### PR TITLE
Added generic key-value parser for parsing command line parameters.

### DIFF
--- a/keyvalues/keyvalues.go
+++ b/keyvalues/keyvalues.go
@@ -1,0 +1,40 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// The keyvalues package implements a set of functions for parsing key=value data,
+// usually passed in as command-line parameters to juju subcommands, e.g.
+// juju-set mongodb logging=true
+package keyvalues
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DuplicateError signals that a duplicate key was encountered while parsing
+// the input into a map.
+type DuplicateError string
+
+func (e DuplicateError) Error() string {
+	return string(e)
+}
+
+// Parse parses the supplied string slice into a map mapping
+// keys to values. Duplicate keys cause an error to be returned.
+func Parse(src []string, allowEmptyValues bool) (map[string]string, error) {
+	results := map[string]string{}
+	for _, kv := range src {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 || len(parts[0]) == 0 {
+			return nil, fmt.Errorf(`expected "key=value", got %q`, kv)
+		}
+		if !allowEmptyValues && len(parts[1]) == 0 {
+			return nil, fmt.Errorf(`expected "key=value", got %q`, kv)
+		}
+		if _, exists := results[parts[0]]; exists {
+			return nil, DuplicateError(fmt.Sprintf("key %q specified more than once", parts[0]))
+		}
+		results[parts[0]] = parts[1]
+	}
+	return results, nil
+}

--- a/keyvalues/keyvalues_test.go
+++ b/keyvalues/keyvalues_test.go
@@ -1,0 +1,101 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package keyvalues_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils/keyvalues"
+)
+
+type keyValuesSuite struct{}
+
+var _ = gc.Suite(&keyValuesSuite{})
+
+var testCases = []struct {
+	about         string
+	input         []string
+	allowEmptyVal bool
+	output        map[string]string
+	error         string
+}{{
+	about:         "simple test case",
+	input:         []string{"key=value"},
+	allowEmptyVal: false,
+	output:        map[string]string{"key": "value"},
+	error:         "",
+}, {
+	about:         "empty list",
+	input:         []string{},
+	allowEmptyVal: false,
+	output:        map[string]string{},
+	error:         "",
+}, {
+	about:         "nil list",
+	input:         nil,
+	allowEmptyVal: false,
+	output:        map[string]string{},
+	error:         "",
+}, {
+	about:         "invalid format - missing value",
+	input:         []string{"key"},
+	allowEmptyVal: false,
+	output:        nil,
+	error:         `expected "key=value", got "key"`,
+}, {
+	about:         "invalid format - missing value",
+	input:         []string{"key="},
+	allowEmptyVal: false,
+	output:        nil,
+	error:         `expected "key=value", got "key="`,
+}, {
+	about:         "invalid format - missing key",
+	input:         []string{"=value"},
+	allowEmptyVal: false,
+	output:        nil,
+	error:         `expected "key=value", got "=value"`,
+}, {
+	about:         "invalid format",
+	input:         []string{"="},
+	allowEmptyVal: false,
+	output:        nil,
+	error:         `expected "key=value", got "="`,
+}, {
+	about:         "invalid format, allowing empty",
+	input:         []string{"="},
+	allowEmptyVal: true,
+	output:        nil,
+	error:         `expected "key=value", got "="`,
+}, {
+	about:         "duplicate keys",
+	input:         []string{"key=value", "key=value"},
+	allowEmptyVal: true,
+	output:        nil,
+	error:         `key "key" specified more than once`,
+}, {
+	about:         "multiple keys",
+	input:         []string{"key=value", "key2=value", "key3=value"},
+	allowEmptyVal: true,
+	output:        map[string]string{"key": "value", "key2": "value", "key3": "value"},
+	error:         "",
+}, {
+	about:         "empty value",
+	input:         []string{"key="},
+	allowEmptyVal: true,
+	output:        map[string]string{"key": ""},
+	error:         "",
+}}
+
+func (keyValuesSuite) TestMapParsing(c *gc.C) {
+	for i, t := range testCases {
+		c.Log("test %d: %s", i, t.about)
+		result, err := keyvalues.Parse(t.input, t.allowEmptyVal)
+		c.Check(result, gc.DeepEquals, t.output)
+		if t.error == "" {
+			c.Check(err, gc.IsNil)
+		} else {
+			c.Check(err, gc.ErrorMatches, t.error)
+		}
+	}
+}

--- a/keyvalues/package_test.go
+++ b/keyvalues/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package keyvalues_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
Parsing key-value pairs from command line parameters is done in more than one place in the juju-core codebase, this package will conver that functionality without repetition.
