### PR TITLE
Extract ParseSize from juju/instance

### DIFF
--- a/size.go
+++ b/size.go
@@ -1,0 +1,51 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package utils
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/juju/errors"
+)
+
+// ParseSize parses the string as a size, in mebibytes.
+//
+// The string must be a is a non-negative number with
+// an optional multiplier suffix (M, G, T or P). If the
+// suffix is not specified, "M" is implied.
+func ParseSize(str string) (MB uint64, err error) {
+	var val float64
+	var suffix string
+	n, _ := fmt.Sscanf(str, "%f%s", &val, &suffix)
+	if n == 0 || val < 0 {
+		return 0, errors.Errorf("expected a non-negative number with optional multiplier suffix (M/G/T/P), got %q", str)
+	}
+	if suffix != "" {
+		multiplier, ok := mbSuffixes[suffix]
+		if !ok {
+			return 0, errors.Errorf("invalid multiplier suffix %q", suffix)
+		}
+		val *= multiplier
+	}
+	return uint64(math.Ceil(val)), nil
+}
+
+var mbSuffixes = map[string]float64{
+	"M":   1,
+	"MB":  1,
+	"MiB": 1,
+
+	"G":   1024,
+	"GB":  1024,
+	"GiB": 1024,
+
+	"T":   1024 * 1024,
+	"TB":  1024 * 1024,
+	"TiB": 1024 * 1024,
+
+	"P":   1024 * 1024 * 1024,
+	"PB":  1024 * 1024 * 1024,
+	"PiB": 1024 * 1024 * 1024,
+}

--- a/size_test.go
+++ b/size_test.go
@@ -1,0 +1,70 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package utils_test
+
+import (
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils"
+)
+
+var _ = gc.Suite(&sizeSuite{})
+
+type sizeSuite struct {
+	testing.IsolationSuite
+}
+
+func (*sizeSuite) TestParseSize(c *gc.C) {
+	type test struct {
+		in  string
+		out uint64
+		err string
+	}
+	tests := []test{{
+		in:  "",
+		err: `expected a non-negative number with optional multiplier suffix \(M/G/T/P\), got ""`,
+	}, {
+		in:  "-1",
+		err: `expected a non-negative number with optional multiplier suffix \(M/G/T/P\), got "-1"`,
+	}, {
+		in:  "1MZ",
+		err: `invalid multiplier suffix "MZ"`,
+	}, {
+		in:  "0",
+		out: 0,
+	}, {
+		in:  "123",
+		out: 123,
+	}, {
+		in:  "1M",
+		out: 1,
+	}, {
+		in:  "0.5G",
+		out: 512,
+	}, {
+		in:  "0.5GB",
+		out: 512,
+	}, {
+		in:  "0.5GiB",
+		out: 512,
+	}, {
+		in:  "0.5T",
+		out: 524288,
+	}, {
+		in:  "0.5P",
+		out: 536870912,
+	}}
+	for i, test := range tests {
+		c.Logf("test %d: %+v", i, test)
+		size, err := utils.ParseSize(test.in)
+		if test.err != "" {
+			c.Assert(err, gc.NotNil)
+			c.Assert(err, gc.ErrorMatches, test.err)
+		} else {
+			c.Assert(err, gc.IsNil)
+			c.Assert(size, gc.Equals, test.out)
+		}
+	}
+}


### PR DESCRIPTION
The ParseSize function will be used to parse
the size in storage specifications.
