### PR TITLE
parallel: more efficient Run

### DIFF
--- a/parallel/parallel.go
+++ b/parallel/parallel.go
@@ -1,8 +1,8 @@
 // Copyright 2013 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
-// The parallel package provides a way of running functions concurrently while
-// limiting the maximum number running at once.
+// The parallel package provides utilities for running tasks
+// concurrently.
 package parallel
 
 import (
@@ -12,10 +12,11 @@ import (
 
 // Run represents a number of functions running concurrently.
 type Run struct {
-	limiter chan struct{}
-	done    chan error
-	err     chan error
-	wg      sync.WaitGroup
+	mu      sync.Mutex
+	results chan Errors
+	max     int
+	running int
+	work    chan func() error
 }
 
 // Errors holds any errors encountered during the parallel run.
@@ -31,54 +32,61 @@ func (errs Errors) Error() string {
 	return fmt.Sprintf("%s (and %d more)", errs[0].Error(), len(errs)-1)
 }
 
-// NewRun returns a new parallel instance.  It will run up to maxParallel
-// functions concurrently.
-func NewRun(maxParallel int) *Run {
-	if maxParallel < 1 {
-		panic("parameter maxParallel must be >= 1")
+// NewRun returns a new parallel instance. It provides a way of running
+// functions concurrently while limiting the maximum number running at
+// once to max.
+func NewRun(max int) *Run {
+	if max < 1 {
+		panic("parameter max must be >= 1")
 	}
-	parallelRun := &Run{
-		limiter: make(chan struct{}, maxParallel),
-		done:    make(chan error),
-		err:     make(chan error),
+	return &Run{
+		max:     max,
+		results: make(chan Errors),
+		work:    make(chan func() error),
 	}
-	go func() {
-		var errs Errors
-		for e := range parallelRun.done {
-			errs = append(errs, e)
-		}
-		// TODO(rog) sort errors by original order of Do request?
-		if len(errs) > 0 {
-			parallelRun.err <- errs
-		} else {
-			parallelRun.err <- nil
-		}
-	}()
-	return parallelRun
 }
 
 // Do requests that r run f concurrently.  If there are already the maximum
 // number of functions running concurrently, it will block until one of them
-// has completed. Do may itself be called concurrently.
-func (parallelRun *Run) Do(f func() error) {
-	parallelRun.limiter <- struct{}{}
-	parallelRun.wg.Add(1)
-	go func() {
-		defer func() {
-			parallelRun.wg.Done()
-			<-parallelRun.limiter
-		}()
-		if err := f(); err != nil {
-			parallelRun.done <- err
-		}
-	}()
+// has completed. Do may itself be called concurrently, but may not be called
+// concurrently with Wait.
+func (r *Run) Do(f func() error) {
+	select {
+	case r.work <- f:
+		return
+	default:
+	}
+	r.mu.Lock()
+	if r.running < r.max {
+		r.running++
+		go r.runner()
+	}
+	r.mu.Unlock()
+	r.work <- f
 }
 
 // Wait marks the parallel instance as complete and waits for all the functions
 // to complete.  If any errors were encountered, it returns an Errors value
 // describing all the errors in arbitrary order.
-func (parallelRun *Run) Wait() error {
-	parallelRun.wg.Wait()
-	close(parallelRun.done)
-	return <-parallelRun.err
+func (r *Run) Wait() error {
+	close(r.work)
+	var errs Errors
+	for i := 0; i < r.running; i++ {
+		errs = append(errs, <-r.results...)
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	// TODO(rog) sort errors by original order of Do request?
+	return errs
+}
+
+func (r *Run) runner() {
+	var errs Errors
+	for f := range r.work {
+		if err := f(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	r.results <- errs
 }


### PR DESCRIPTION
We refactor Run to make it faster and more memory efficient.

Also added some benchmarks to verify this:

benchmark                old ns/op     new ns/op     delta
BenchmarkRunSingle       3163          1933          -38.89%
BenchmarkRun1000p100     714010        379910        -46.79%

benchmark                old allocs     new allocs     delta
BenchmarkRunSingle       10             3              -70.00%
BenchmarkRun1000p100     3007           3              -99.90%

benchmark                old bytes     new bytes     delta
BenchmarkRunSingle       412           240           -41.75%
BenchmarkRun1000p100     48394         240           -99.50%
