### PR TITLE
Drop Copy() from the Document interface.

### DIFF
--- a/filestorage/interfaces.go
+++ b/filestorage/interfaces.go
@@ -40,9 +40,6 @@ type Document interface {
 	// SetID sets the ID of the document.  If the ID is already set,
 	// SetID() should return true (false otherwise).
 	SetID(id string) (alreadySet bool)
-
-	// Copy returns a new copy of the metadata with an empty ID.
-	Copy() Document
 }
 
 // Metadata is the meta information for a stored file.

--- a/filestorage/metadata.go
+++ b/filestorage/metadata.go
@@ -35,13 +35,6 @@ func (d *Doc) SetID(id string) bool {
 	return false
 }
 
-// Copy returns a copy of the document.
-func (d *Doc) Copy() Document {
-	copied := *d
-	copied.Raw.ID = ""
-	return &copied
-}
-
 // RawFileMetadata holds info specific to stored files.
 type RawFileMetadata struct {
 	// Size is the size (in bytes) of the stored file.
@@ -124,12 +117,4 @@ func (m *FileMetadata) SetStored(timestamp *time.Time) {
 	} else {
 		m.Raw.Stored = timestamp
 	}
-}
-
-// Copy returns a copy of the document.
-func (m *FileMetadata) Copy() Document {
-	copied := *m
-	doc := m.Doc.Copy().(*Doc)
-	copied.Doc = *doc
-	return &copied
 }

--- a/filestorage/metadata_test.go
+++ b/filestorage/metadata_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/juju/testing"
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/utils/filestorage"
@@ -94,19 +93,4 @@ func (s *MetadataSuite) TestFileMetadataSetStoredDefault(c *gc.C) {
 	meta.SetStored(nil)
 
 	c.Check(meta.Stored(), gc.NotNil)
-}
-
-func (s *MetadataSuite) TestFileMetadataCopy(c *gc.C) {
-	meta := filestorage.NewMetadata()
-	meta.SetFileInfo(10, "some sum", "SHA-1")
-	meta.SetID("spam")
-
-	doc := meta.Copy()
-	copied, ok := doc.(filestorage.Metadata)
-	c.Assert(ok, jc.IsTrue)
-
-	c.Check(copied.ID(), gc.Equals, "")
-	copied.SetID(meta.ID())
-	c.Check(copied, gc.Not(gc.Equals), meta)
-	c.Check(copied, gc.DeepEquals, meta)
 }


### PR DESCRIPTION
It was used in code that has since been dropped.  It's otherwise not worth the complexity.
