### PR TITLE
Grouped platform-specific system error message regex-es.

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -8,5 +8,4 @@ var (
 	NumCPU     = &numCPU
 	Dial       = dial
 	NetDial    = &netDial
-	NoSuchUser = noSuchUser
 )

--- a/file_test.go
+++ b/file_test.go
@@ -60,7 +60,7 @@ func (*fileSuite) TestNormalizePath(c *gc.C) {
 		expected: filepath.FromSlash("foo~bar/baz"),
 	}, {
 		path: "~foobar/path",
-		err:  utils.NoSuchUser,
+		err:  ".*" + utils.NoSuchUserErrRegexp,
 	}} {
 		c.Logf("test %d: %s", i, test.path)
 		actual, err := utils.NormalizePath(test.path)

--- a/file_unix.go
+++ b/file_unix.go
@@ -9,14 +9,14 @@ import (
 	"os"
 	"os/user"
 	"strings"
-)
 
-var noSuchUser = `user: unknown user [a-zA-Z0-9]+`
+	"github.com/juju/errors"
+)
 
 func homeDir(userName string) (string, error) {
 	u, err := user.Lookup(userName)
 	if err != nil {
-		return "", err
+		return "", errors.NewUserNotFound(err, "no such user")
 	}
 	return u.HomeDir, nil
 }

--- a/file_windows_test.go
+++ b/file_windows_test.go
@@ -18,25 +18,25 @@ type windowsFileSuite struct {
 var _ = gc.Suite(&windowsFileSuite{})
 
 func (s *windowsFileSuite) TestMakeFileURL(c *gc.C) {
-   var makeFileURLTests = []struct {
-       in string
-       expected string
-   }{{
-       in:       "file://C:\\foo\\baz",
-       expected: "file://\\\\localhost\\C$/foo/baz",
-   }, {
-       in:       "C:\\foo\\baz",
-       expected: "file://\\\\localhost\\C$/foo/baz",
-   }, {
-       in:       "http://foo/baz",
-       expected: "http://foo/baz",
-   }, {
-       in:       "file://\\\\localhost\\C$/foo/baz",
-       expected: "file://\\\\localhost\\C$/foo/baz",
-   }}
+	var makeFileURLTests = []struct {
+		in       string
+		expected string
+	}{{
+		in:       "file://C:\\foo\\baz",
+		expected: "file://\\\\localhost\\C$/foo/baz",
+	}, {
+		in:       "C:\\foo\\baz",
+		expected: "file://\\\\localhost\\C$/foo/baz",
+	}, {
+		in:       "http://foo/baz",
+		expected: "http://foo/baz",
+	}, {
+		in:       "file://\\\\localhost\\C$/foo/baz",
+		expected: "file://\\\\localhost\\C$/foo/baz",
+	}}
 
-   for i, t := range makeFileURLTests {
-       c.Logf("Test %d", i)
-       c.Assert(utils.MakeFileURL(t.in), gc.Equals,t.expected)
-   }
+	for i, t := range makeFileURLTests {
+		c.Logf("Test %d", i)
+		c.Assert(utils.MakeFileURL(t.in), gc.Equals, t.expected)
+	}
 }

--- a/systemerrmessages_unix.go
+++ b/systemerrmessages_unix.go
@@ -1,0 +1,15 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// +build !windows
+
+package utils
+
+// The following are strings/regex-es which match common Unix error messages
+// that may be returned in case of failed calls to the system.
+// Any extra leading/trailing regex-es are left to be added by the developer.
+const (
+	NoSuchUserErrRegexp = `user: unknown user [a-z0-9_-]*`
+	NoSuchFileErrRegexp = `no such file or directory`
+)

--- a/systemerrmessages_windows.go
+++ b/systemerrmessages_windows.go
@@ -1,0 +1,13 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package utils
+
+// The following are strings/regex-es which match common Windows error messages
+// that may be returned in case of failed calls to the system.
+// Any extra leading/trailing regex-es are left to be added by the developer.
+const (
+	NoSuchUserErrRegexp = `No mapping between account names and security IDs was done\.`
+	NoSuchFileErrRegexp = `The system cannot find the (file|path) specified\.`
+)


### PR DESCRIPTION
The two files contain the couple of platform-specific error message-matching regex-es I have found so far with more to be added as we go along.

These provide an easier and more standardised means of checking for those specific error outputs generated by failed system calls using gc.Matches and gc.ErrorMatches.

This pull depends on the UserNotFound error type included in [this](https://github.com/juju/errors/pull/14) pull request.

(Review request: http://reviews.vapour.ws/r/547/)
