### PR TITLE
use golang.org/x/crypto

### DIFF
--- a/password.go
+++ b/password.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"io"
 
-	"code.google.com/p/go.crypto/pbkdf2"
+	"golang.org/x/crypto/pbkdf2"
 )
 
 // CompatSalt is because Juju 1.16 and older used a hard-coded salt to compute

--- a/readpass/readpass.go
+++ b/readpass/readpass.go
@@ -6,7 +6,7 @@ package readpass
 import (
 	"os"
 
-	"code.google.com/p/go.crypto/ssh/terminal"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 func ReadPassword() (string, error) {


### PR DESCRIPTION
This is the new canonical import path for go.crypto.

(Review request: http://reviews.vapour.ws/r/636/)
