### PR TITLE
Empty feature flag is always enabled.

### DIFF
--- a/featureflag/flags.go
+++ b/featureflag/flags.go
@@ -51,6 +51,10 @@ func SetFlagsFromEnvironment(envVarName string) {
 // the process.
 func Enabled(flag string) bool {
 	flag = strings.TrimSpace(strings.ToLower(flag))
+	if flag == "" {
+		// The empty feature is always enabled.
+		return true
+	}
 	return flags.Contains(flag)
 }
 

--- a/featureflag/flags_test.go
+++ b/featureflag/flags_test.go
@@ -34,6 +34,8 @@ func (s *flagSuite) TestParsing(c *gc.C) {
 }
 
 func (s *flagSuite) TestEnabled(c *gc.C) {
+	c.Assert(featureflag.Enabled(""), jc.IsTrue)
+	c.Assert(featureflag.Enabled(" "), jc.IsTrue)
 	c.Assert(featureflag.Enabled("magic"), jc.IsFalse)
 
 	s.PatchEnvironment("JUJU_TESTING_FEATURE", "MAGIC")


### PR DESCRIPTION
This makes other code using it easier.

(Review request: http://reviews.vapour.ws/r/787/)