### PR TITLE
Corrected licence AGPL3->LGPL3

### DIFF
--- a/filestorage/doc.go
+++ b/filestorage/doc.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 /*
 utils/filestorage provides types for abstracting and implementing a

--- a/filestorage/interfaces.go
+++ b/filestorage/interfaces.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package filestorage
 

--- a/filestorage/metadata.go
+++ b/filestorage/metadata.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package filestorage
 

--- a/filestorage/wrapper.go
+++ b/filestorage/wrapper.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package filestorage
 

--- a/hash/package_test.go
+++ b/hash/package_test.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package hash_test
 

--- a/hash/writer.go
+++ b/hash/writer.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package hash
 

--- a/hash/writer_test.go
+++ b/hash/writer_test.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package hash_test
 

--- a/keyvalues/keyvalues.go
+++ b/keyvalues/keyvalues.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 // The keyvalues package implements a set of functions for parsing key=value data,
 // usually passed in as command-line parameters to juju subcommands, e.g.

--- a/uptime/uptime_nix.go
+++ b/uptime/uptime_nix.go
@@ -1,6 +1,6 @@
 // Copyright 2014 Cloudbase Solutions SRL
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 //
 // +build !windows
 

--- a/uptime/uptime_windows.go
+++ b/uptime/uptime_windows.go
@@ -1,6 +1,6 @@
 // Copyright 2014 Cloudbase Solutions SRL
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package uptime
 


### PR DESCRIPTION
Several files had the wrong licence due to copy and paste from the wrong place, the licence headers where corrected.Several files had the wrong licence due to copy and paste from the wrong place, the licence headers where corrected.

(Review request: http://reviews.vapour.ws/r/887/)