### PR TITLE
Copy the functionality of path/filepath independent of the current OS.

### DIFF
--- a/LICENSE.Go
+++ b/LICENSE.Go
@@ -1,0 +1,27 @@
+Copyright (c) 2010 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/filepath/filepath.go
+++ b/filepath/filepath.go
@@ -1,0 +1,76 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filepath
+
+import (
+	"runtime"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+// Renderer provides methods for the different functions in
+// the stdlib path/filepath package that don't relate to a concrete
+// filesystem. So Abs, EvalSymlinks, Glob, Rel, and Walk are not
+// included. Also, while the functions in path/filepath relate to the
+// current host, the PathRenderer methods relate to the renderer's
+// target platform. So for example, a windows-oriented implementation
+// will give windows-specific results even when used on linux.
+type Renderer interface {
+	// Base mimics path/filepath.
+	Base(path string) string
+
+	// Clean mimics path/filepath.
+	Clean(path string) string
+
+	// Dir mimics path/filepath.
+	Dir(path string) string
+
+	// Ext mimics path/filepath.
+	Ext(path string) string
+
+	// FromSlash mimics path/filepath.
+	FromSlash(path string) string
+
+	// IsAbs mimics path/filepath.
+	IsAbs(path string) bool
+
+	// Join mimics path/filepath.
+	Join(path ...string) string
+
+	// Match mimics path/filepath.
+	Match(pattern, name string) (matched bool, err error)
+
+	// Split mimics path/filepath.
+	Split(path string) (dir, file string)
+
+	// SplitList mimics path/filepath.
+	SplitList(path string) []string
+
+	// ToSlash mimics path/filepath.
+	ToSlash(path string) string
+
+	// VolumeName mimics path/filepath.
+	VolumeName(path string) string
+}
+
+// NewRenderer returns a Renderer for the given os.
+func NewRenderer(os string) (Renderer, error) {
+	if os == "" {
+		os = runtime.GOOS
+	}
+
+	switch strings.ToLower(os) {
+	case "windows":
+		return &windowsRenderer{}, nil
+	case "ubuntu":
+		return &unixRenderer{}, nil
+	case "darwin", "dragonfly", "freebsd", "linux", "nacl", "netbsd", "openbsd", "solaris":
+		// These match the the OS names from
+		// http://golang.org/src/path/filepath/path_unix.go.
+		return &unixRenderer{}, nil
+	default:
+		return nil, errors.NotFoundf("renderer for %q", os)
+	}
+}

--- a/filepath/filepath.go
+++ b/filepath/filepath.go
@@ -63,13 +63,13 @@ func NewRenderer(os string) (Renderer, error) {
 
 	switch strings.ToLower(os) {
 	case "windows":
-		return &windowsRenderer{}, nil
+		return &WindowsRenderer{}, nil
 	case "ubuntu":
-		return &unixRenderer{}, nil
+		return &UnixRenderer{}, nil
 	case "darwin", "dragonfly", "freebsd", "linux", "nacl", "netbsd", "openbsd", "solaris":
 		// These match the the OS names from
 		// http://golang.org/src/path/filepath/path_unix.go.
-		return &unixRenderer{}, nil
+		return &UnixRenderer{}, nil
 	default:
 		return nil, errors.NotFoundf("renderer for %q", os)
 	}

--- a/filepath/filepath.go
+++ b/filepath/filepath.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils"
 )
 
 // Renderer provides methods for the different functions in
@@ -61,14 +62,13 @@ func NewRenderer(os string) (Renderer, error) {
 		os = runtime.GOOS
 	}
 
-	switch strings.ToLower(os) {
-	case "windows":
+	os = strings.ToLower(os)
+	switch {
+	case os == utils.OSWindows:
 		return &WindowsRenderer{}, nil
-	case "ubuntu":
+	case utils.OSIsUnix(os):
 		return &UnixRenderer{}, nil
-	case "darwin", "dragonfly", "freebsd", "linux", "nacl", "netbsd", "openbsd", "solaris":
-		// These match the the OS names from
-		// http://golang.org/src/path/filepath/path_unix.go.
+	case os == "ubuntu":
 		return &UnixRenderer{}, nil
 	default:
 		return nil, errors.NotFoundf("renderer for %q", os)

--- a/filepath/filepath_test.go
+++ b/filepath/filepath_test.go
@@ -1,0 +1,103 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filepath_test
+
+import (
+	"runtime"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils/filepath"
+)
+
+type filepathSuite struct {
+	testing.IsolationSuite
+
+	unix    *filepath.UnixRenderer
+	windows *filepath.WindowsRenderer
+}
+
+var _ = gc.Suite(&filepathSuite{})
+
+func (s *filepathSuite) SetupTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.unix = &filepath.UnixRenderer{}
+	s.windows = &filepath.WindowsRenderer{}
+}
+
+func (s filepathSuite) checkRenderer(c *gc.C, renderer filepath.Renderer, expected string) {
+	switch expected {
+	case "windows":
+		c.Check(renderer, gc.FitsTypeOf, s.windows)
+	case "unix":
+		c.Check(renderer, gc.FitsTypeOf, s.unix)
+	default:
+		c.Errorf("unknown kind %q", expected)
+	}
+}
+
+func (s filepathSuite) TestNewRendererDefault(c *gc.C) {
+	// All possible values of runtime.GOOS should be supported.
+	renderer, err := filepath.NewRenderer("")
+	c.Assert(err, jc.ErrorIsNil)
+
+	switch runtime.GOOS {
+	case "windows":
+		s.checkRenderer(c, renderer, "windows")
+	default:
+		s.checkRenderer(c, renderer, "unix")
+	}
+}
+
+func (s filepathSuite) TestNewRendererGOOS(c *gc.C) {
+	// All possible values of runtime.GOOS should be supported.
+	renderer, err := filepath.NewRenderer(runtime.GOOS)
+	c.Assert(err, jc.ErrorIsNil)
+
+	switch runtime.GOOS {
+	case "windows":
+		s.checkRenderer(c, renderer, "windows")
+	default:
+		s.checkRenderer(c, renderer, "unix")
+	}
+}
+
+func (s filepathSuite) TestNewRendererWindows(c *gc.C) {
+	renderer, err := filepath.NewRenderer("windows")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkRenderer(c, renderer, "windows")
+}
+
+func (s filepathSuite) TestNewRendererUnix(c *gc.C) {
+	for _, os := range utils.OSUnix {
+		c.Logf("trying %q", os)
+		renderer, err := filepath.NewRenderer(os)
+		c.Assert(err, jc.ErrorIsNil)
+
+		s.checkRenderer(c, renderer, "unix")
+	}
+}
+
+func (s filepathSuite) TestNewRendererDistros(c *gc.C) {
+	distros := []string{"ubuntu"}
+	for _, distro := range distros {
+		c.Logf("trying %q", distro)
+		renderer, err := filepath.NewRenderer(distro)
+		c.Assert(err, jc.ErrorIsNil)
+
+		s.checkRenderer(c, renderer, "unix")
+	}
+}
+
+func (s filepathSuite) TestNewRendererUnknown(c *gc.C) {
+	_, err := filepath.NewRenderer("<unknown OS>")
+
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+}

--- a/filepath/interface_test.go
+++ b/filepath/interface_test.go
@@ -1,0 +1,7 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package filepath
+
+var _ Renderer = (*unixRenderer)(nil)
+var _ Renderer = (*windowsRenderer)(nil)

--- a/filepath/interface_test.go
+++ b/filepath/interface_test.go
@@ -3,5 +3,5 @@
 
 package filepath
 
-var _ Renderer = (*unixRenderer)(nil)
-var _ Renderer = (*windowsRenderer)(nil)
+var _ Renderer = (*UnixRenderer)(nil)
+var _ Renderer = (*WindowsRenderer)(nil)

--- a/filepath/package_test.go
+++ b/filepath/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package filepath_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/filepath/stdlib.go
+++ b/filepath/stdlib.go
@@ -1,0 +1,207 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filepath
+
+import (
+	"strings"
+)
+
+// The following functions are adapted from the GO stdlib source.
+
+// Base mimics path/filepath for the given path separator.
+func Base(sep uint8, volumeName func(string) string, path string) string {
+	if path == "" {
+		return "."
+	}
+	// Strip trailing slashes.
+	for len(path) > 0 && path[len(path)-1] == sep {
+		path = path[0 : len(path)-1]
+	}
+	// Throw away volume name
+	path = path[len(volumeName(path)):]
+	// Find the last element
+	i := len(path) - 1
+	for i >= 0 && path[i] != sep {
+		i--
+	}
+	if i >= 0 {
+		path = path[i+1:]
+	}
+	// If empty now, it had only slashes.
+	if path == "" {
+		return string(sep)
+	}
+	return path
+}
+
+// A lazybuf is a lazily constructed path buffer.
+// It supports append, reading previously appended bytes,
+// and retrieving the final string. It does not allocate a buffer
+// to hold the output until that output diverges from s.
+type lazybuf struct {
+	path       string
+	buf        []byte
+	w          int
+	volAndPath string
+	volLen     int
+}
+
+func (b *lazybuf) index(i int) byte {
+	if b.buf != nil {
+		return b.buf[i]
+	}
+	return b.path[i]
+}
+
+func (b *lazybuf) append(c byte) {
+	if b.buf == nil {
+		if b.w < len(b.path) && b.path[b.w] == c {
+			b.w++
+			return
+		}
+		b.buf = make([]byte, len(b.path))
+		copy(b.buf, b.path[:b.w])
+	}
+	b.buf[b.w] = c
+	b.w++
+}
+
+func (b *lazybuf) string() string {
+	if b.buf == nil {
+		return b.volAndPath[:b.volLen+b.w]
+	}
+	return b.volAndPath[:b.volLen] + string(b.buf[:b.w])
+}
+
+// Clean mimics path/filepath for the given path separator.
+func Clean(sep uint8, volumeName func(string) string, path string) string {
+	originalPath := path
+	volLen := len(volumeName(path))
+	path = path[volLen:]
+	if path == "" {
+		if volLen > 1 && originalPath[1] != ':' {
+			// should be UNC
+			return FromSlash(sep, originalPath)
+		}
+		return originalPath + "."
+	}
+	rooted := (path[0] == sep)
+
+	// Invariants:
+	//  reading from path; r is index of next byte to process.
+	//  writing to buf; w is index of next byte to write.
+	//  dotdot is index in buf where .. must stop, either because
+	//      it is the leading slash or it is a leading ../../.. prefix.
+	n := len(path)
+	out := lazybuf{path: path, volAndPath: originalPath, volLen: volLen}
+	r, dotdot := 0, 0
+	if rooted {
+		out.append(sep)
+		r, dotdot = 1, 1
+	}
+
+	for r < n {
+		switch {
+		case path[r] == sep:
+			// empty path element
+			r++
+		case path[r] == '.' && (r+1 == n || path[r+1] == sep):
+			// . element
+			r++
+		case path[r] == '.' && path[r+1] == '.' && (r+2 == n || path[r+2] == sep):
+			// .. element: remove to last separator
+			r += 2
+			switch {
+			case out.w > dotdot:
+				// can backtrack
+				out.w--
+				for out.w > dotdot && out.index(out.w) != sep {
+					out.w--
+				}
+			case !rooted:
+				// cannot backtrack, but not rooted, so append .. element.
+				if out.w > 0 {
+					out.append(sep)
+				}
+				out.append('.')
+				out.append('.')
+				dotdot = out.w
+			}
+		default:
+			// real path element.
+			// add slash if needed
+			if rooted && out.w != 1 || !rooted && out.w != 0 {
+				out.append(sep)
+			}
+			// copy element
+			for ; r < n && path[r] != sep; r++ {
+				out.append(path[r])
+			}
+		}
+	}
+
+	// Turn empty string into "."
+	if out.w == 0 {
+		out.append('.')
+	}
+
+	return FromSlash(sep, out.string())
+}
+
+// Dir mimics path/filepath for the given path separator.
+func Dir(sep uint8, volumeName func(string) string, path string) string {
+	vol := volumeName(path)
+	i := len(path) - 1
+	for i >= len(vol) && path[i] != sep {
+		i--
+	}
+	dir := Clean(sep, volumeName, path[len(vol):i+1])
+	return vol + dir
+}
+
+// Ext mimics path/filepath for the given path separator.
+func Ext(sep uint8, path string) string {
+	for i := len(path) - 1; i >= 0 && path[i] != sep; i-- {
+		if path[i] == '.' {
+			return path[i:]
+		}
+	}
+	return ""
+}
+
+// FromSlash mimics path/filepath for the given path separator.
+func FromSlash(sep uint8, path string) string {
+	if sep == '/' {
+		return path
+	}
+	return strings.Replace(path, "/", string(sep), -1)
+}
+
+// Join mimics path/filepath for the given path separator.
+func Join(sep uint8, volumeName func(string) string, elem ...string) string {
+	for i, e := range elem {
+		if e != "" {
+			return Clean(sep, volumeName, strings.Join(elem[i:], string(sep)))
+		}
+	}
+	return ""
+}
+
+// Split mimics path/filepath for the given path separator.
+func Split(sep uint8, volumeName func(string) string, path string) (dir, file string) {
+	vol := volumeName(path)
+	i := len(path) - 1
+	for i >= len(vol) && path[i] != sep {
+		i--
+	}
+	return path[:i+1], path[i+1:]
+}
+
+// ToSlash mimics path/filepath for the given path separator.
+func ToSlash(sep uint8, path string) string {
+	if sep == '/' {
+		return path
+	}
+	return strings.Replace(path, string(sep), "/", -1)
+}

--- a/filepath/stdlib.go
+++ b/filepath/stdlib.go
@@ -1,5 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.Go file.
 
 package filepath
 

--- a/filepath/stdlib_test.go
+++ b/filepath/stdlib_test.go
@@ -1,0 +1,186 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filepath_test
+
+import (
+	gofilepath "path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils/filepath"
+)
+
+// The tests here are mostly just sanity checks against the behavior
+// of the stdlib path/filepath. We are not trying for high coverage levels.
+
+type stdlibSuite struct {
+	testing.IsolationSuite
+
+	path       string
+	volumeName func(string) string
+}
+
+var _ = gc.Suite(&stdlibSuite{})
+
+func (s *stdlibSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	switch runtime.GOOS {
+	case "windows":
+		s.path = `C:\a\b\c.xyz`
+		s.volumeName = func(path string) string {
+			return "C:"
+		}
+	default:
+		s.path = "/a/b/c.xyz"
+		s.volumeName = func(string) string { return "" }
+	}
+}
+
+func (s stdlibSuite) TestBase(c *gc.C) {
+	path := filepath.Base(gofilepath.Separator, s.volumeName, s.path)
+
+	gopath := gofilepath.Base(s.path)
+	c.Check(path, gc.Equals, gopath)
+	c.Check(path, gc.Equals, "c.xyz")
+}
+
+func (s stdlibSuite) TestClean(c *gc.C) {
+	// TODO(ericsnow) Add more cases.
+	originals := map[string]string{
+		s.path: s.path,
+	}
+	for original, expected := range originals {
+		c.Logf("checking %q", original)
+		path := filepath.Clean(gofilepath.Separator, s.volumeName, original)
+
+		gopath := gofilepath.Clean(original)
+		c.Check(path, gc.Equals, gopath)
+		c.Check(path, gc.Equals, expected)
+	}
+}
+
+func (s stdlibSuite) TestDir(c *gc.C) {
+	path := filepath.Dir(gofilepath.Separator, s.volumeName, s.path)
+
+	gopath := gofilepath.Dir(s.path)
+	c.Check(path, gc.Equals, gopath)
+	switch runtime.GOOS {
+	case "windows":
+		c.Check(path, gc.Equals, `\a\b`)
+	default:
+		c.Check(path, gc.Equals, "/a/b")
+	}
+}
+
+func (s stdlibSuite) TestExt(c *gc.C) {
+	ext := filepath.Ext(gofilepath.Separator, s.path)
+
+	goext := gofilepath.Ext(s.path)
+	c.Check(ext, gc.Equals, goext)
+	c.Check(ext, gc.Equals, ".xyz")
+}
+
+func (s stdlibSuite) TestFromSlash(c *gc.C) {
+	original := "/a/b/c.xyz"
+	path := filepath.FromSlash(gofilepath.Separator, original)
+
+	gopath := gofilepath.FromSlash(original)
+	c.Check(path, gc.Equals, gopath)
+	c.Check(path, gc.Equals, s.path)
+}
+
+func (s stdlibSuite) TestJoin(c *gc.C) {
+	path := filepath.Join(gofilepath.Separator, s.volumeName, "a", "b", "c.xyz")
+
+	gopath := gofilepath.Join("a", "b", "c.xyz")
+	c.Check(path, gc.Equals, gopath)
+	expected := s.path[strings.Index(s.path, string(gofilepath.Separator))+1:]
+	c.Check(path, gc.Equals, expected)
+}
+
+func (s stdlibSuite) TestSplit(c *gc.C) {
+	dir, base := filepath.Split(gofilepath.Separator, s.volumeName, s.path)
+
+	godir, gobase := gofilepath.Split(s.path)
+	c.Check(dir, gc.Equals, godir)
+	c.Check(base, gc.Equals, gobase)
+	switch runtime.GOOS {
+	case "windows":
+		c.Check(dir, gc.Equals, `\a\b\`)
+	default:
+		c.Check(dir, gc.Equals, "/a/b/")
+	}
+	c.Check(base, gc.Equals, "c.xyz")
+}
+
+func (s stdlibSuite) TestToSlash(c *gc.C) {
+	path := filepath.ToSlash(gofilepath.Separator, s.path)
+
+	gopath := gofilepath.ToSlash(s.path)
+	c.Check(path, gc.Equals, gopath)
+	c.Check(path, gc.Equals, "/a/b/c.xyz")
+}
+
+func (s stdlibSuite) TestMatchTrue(c *gc.C) {
+	tests := map[string]string{
+		"abc":   "abc",
+		"ab[c]": "abc",
+		"":      "",
+		"*":     "abc",
+		"a*c":   "abc",
+		"?":     "a",
+		"a?c":   "abc",
+	}
+	for pattern, name := range tests {
+		c.Logf("- checking pattern %q against %q -", pattern, name)
+		matched, err := filepath.Match(gofilepath.Separator, pattern, name)
+		c.Assert(err, jc.ErrorIsNil)
+
+		gomatched, err := gofilepath.Match(pattern, name)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(matched, gc.Equals, gomatched)
+		c.Check(matched, jc.IsTrue)
+	}
+}
+
+func (s stdlibSuite) TestMatchFalse(c *gc.C) {
+	tests := map[string]string{
+		"abc": "xyz",
+		"":    "abc",
+		"a*c": "a",
+		"?":   "",
+		"a?c": "ac",
+	}
+	for pattern, name := range tests {
+		c.Logf("- checking pattern %q against %q -", pattern, name)
+		matched, err := filepath.Match(gofilepath.Separator, pattern, name)
+		c.Assert(err, jc.ErrorIsNil)
+
+		gomatched, err := gofilepath.Match(pattern, name)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(matched, gc.Equals, gomatched)
+		c.Check(matched, jc.IsFalse)
+	}
+}
+
+func (s stdlibSuite) TestMatchBadPattern(c *gc.C) {
+	tests := map[string]string{
+		"ab[":    "abc",
+		"ab[-c]": "abc",
+		"ab[]":   "abc",
+	}
+	for pattern, name := range tests {
+		c.Logf("- checking pattern %q against %q -", pattern, name)
+		_, err := filepath.Match(gofilepath.Separator, pattern, name)
+
+		_, goerr := gofilepath.Match(pattern, name)
+		c.Check(err, gc.Equals, goerr)
+		c.Check(err, gc.Equals, gofilepath.ErrBadPattern)
+	}
+}

--- a/filepath/stdlibmatch.go
+++ b/filepath/stdlibmatch.go
@@ -1,0 +1,219 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filepath
+
+import (
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+)
+
+// The following functions are adapted from the GO stdlib source.
+
+// Match returns true if name matches the shell file name pattern.
+// The pattern syntax is:
+//
+//  pattern:
+//      { term }
+//  term:
+//      '*'         matches any sequence of non-Separator characters
+//      '?'         matches any single non-Separator character
+//      '[' [ '^' ] { character-range } ']'
+//                  character class (must be non-empty)
+//      c           matches character c (c != '*', '?', '\\', '[')
+//      '\\' c      matches character c
+//
+//  character-range:
+//      c           matches character c (c != '\\', '-', ']')
+//      '\\' c      matches character c
+//      lo '-' hi   matches character c for lo <= c <= hi
+//
+// Match requires pattern to match all of name, not just a substring.
+// The only possible returned error is ErrBadPattern, when pattern
+// is malformed.
+//
+// On Windows, escaping is disabled. Instead, '\\' is treated as
+// path separator.
+//
+func Match(sep uint8, pattern, name string) (matched bool, err error) {
+Pattern:
+	for len(pattern) > 0 {
+		var star bool
+		var chunk string
+		star, chunk, pattern = scanChunk(sep, pattern)
+		if star && chunk == "" {
+			// Trailing * matches rest of string unless it has a /.
+			return strings.Index(name, string(sep)) < 0, nil
+		}
+		// Look for match at current position.
+		t, ok, err := matchChunk(sep, chunk, name)
+		// if we're the last chunk, make sure we've exhausted the name
+		// otherwise we'll give a false result even if we could still match
+		// using the star
+		if ok && (len(t) == 0 || len(pattern) > 0) {
+			name = t
+			continue
+		}
+		if err != nil {
+			return false, err
+		}
+		if star {
+			// Look for match skipping i+1 bytes.
+			// Cannot skip /.
+			for i := 0; i < len(name) && name[i] != sep; i++ {
+				t, ok, err := matchChunk(sep, chunk, name[i+1:])
+				if ok {
+					// if we're the last chunk, make sure we exhausted the name
+					if len(pattern) == 0 && len(t) > 0 {
+						continue
+					}
+					name = t
+					continue Pattern
+				}
+				if err != nil {
+					return false, err
+				}
+			}
+		}
+		return false, nil
+	}
+	return len(name) == 0, nil
+}
+
+// scanChunk gets the next segment of pattern, which is a non-star string
+// possibly preceded by a star.
+func scanChunk(sep uint8, pattern string) (star bool, chunk, rest string) {
+	for len(pattern) > 0 && pattern[0] == '*' {
+		pattern = pattern[1:]
+		star = true
+	}
+	inrange := false
+	var i int
+Scan:
+	for i = 0; i < len(pattern); i++ {
+		switch pattern[i] {
+		case '\\':
+			if sep == '\\' {
+				// error check handled in matchChunk: bad pattern.
+				if i+1 < len(pattern) {
+					i++
+				}
+			}
+		case '[':
+			inrange = true
+		case ']':
+			inrange = false
+		case '*':
+			if !inrange {
+				break Scan
+			}
+		}
+	}
+	return star, pattern[0:i], pattern[i:]
+}
+
+// matchChunk checks whether chunk matches the beginning of s.
+// If so, it returns the remainder of s (after the match).
+// Chunk is all single-character operators: literals, char classes, and ?.
+func matchChunk(sep uint8, chunk, s string) (rest string, ok bool, err error) {
+	for len(chunk) > 0 {
+		if len(s) == 0 {
+			return
+		}
+		switch chunk[0] {
+		case '[':
+			// character class
+			r, n := utf8.DecodeRuneInString(s)
+			s = s[n:]
+			chunk = chunk[1:]
+			// We can't end right after '[', we're expecting at least
+			// a closing bracket and possibly a caret.
+			if len(chunk) == 0 {
+				err = filepath.ErrBadPattern
+				return
+			}
+			// possibly negated
+			negated := chunk[0] == '^'
+			if negated {
+				chunk = chunk[1:]
+			}
+			// parse all ranges
+			match := false
+			nrange := 0
+			for {
+				if len(chunk) > 0 && chunk[0] == ']' && nrange > 0 {
+					chunk = chunk[1:]
+					break
+				}
+				var lo, hi rune
+				if lo, chunk, err = getEsc(sep, chunk); err != nil {
+					return
+				}
+				hi = lo
+				if chunk[0] == '-' {
+					if hi, chunk, err = getEsc(sep, chunk[1:]); err != nil {
+						return
+					}
+				}
+				if lo <= r && r <= hi {
+					match = true
+				}
+				nrange++
+			}
+			if match == negated {
+				return
+			}
+
+		case '?':
+			if s[0] == sep {
+				return
+			}
+			_, n := utf8.DecodeRuneInString(s)
+			s = s[n:]
+			chunk = chunk[1:]
+
+		case '\\':
+			if sep != '\\' {
+				chunk = chunk[1:]
+				if len(chunk) == 0 {
+					err = filepath.ErrBadPattern
+					return
+				}
+			}
+			fallthrough
+
+		default:
+			if chunk[0] != s[0] {
+				return
+			}
+			s = s[1:]
+			chunk = chunk[1:]
+		}
+	}
+	return s, true, nil
+}
+
+// getEsc gets a possibly-escaped character from chunk, for a character class.
+func getEsc(sep uint8, chunk string) (r rune, nchunk string, err error) {
+	if len(chunk) == 0 || chunk[0] == '-' || chunk[0] == ']' {
+		err = filepath.ErrBadPattern
+		return
+	}
+	if chunk[0] == '\\' && sep != '\\' {
+		chunk = chunk[1:]
+		if len(chunk) == 0 {
+			err = filepath.ErrBadPattern
+			return
+		}
+	}
+	r, n := utf8.DecodeRuneInString(chunk)
+	if r == utf8.RuneError && n == 1 {
+		err = filepath.ErrBadPattern
+	}
+	nchunk = chunk[n:]
+	if len(nchunk) == 0 {
+		err = filepath.ErrBadPattern
+	}
+	return
+}

--- a/filepath/stdlibmatch.go
+++ b/filepath/stdlibmatch.go
@@ -1,5 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.Go file.
 
 package filepath
 

--- a/filepath/unix.go
+++ b/filepath/unix.go
@@ -14,55 +14,56 @@ const (
 	UnixListSeparator = ':' // OS-specific path list separator
 )
 
-type unixRenderer struct{}
+// UnixRenderer is a Renderer implementation for most flavors of Unix.
+type UnixRenderer struct{}
 
 // Base implements Renderer.
-func (ur unixRenderer) Base(path string) string {
+func (ur UnixRenderer) Base(path string) string {
 	return Base(UnixSeparator, ur.VolumeName, path)
 }
 
 // Clean implements Renderer.
-func (ur unixRenderer) Clean(path string) string {
+func (ur UnixRenderer) Clean(path string) string {
 	return Clean(UnixSeparator, ur.VolumeName, path)
 }
 
 // Dir implements Renderer.
-func (ur unixRenderer) Dir(path string) string {
+func (ur UnixRenderer) Dir(path string) string {
 	return Dir(UnixSeparator, ur.VolumeName, path)
 }
 
 // Ext implements Renderer.
-func (unixRenderer) Ext(path string) string {
+func (UnixRenderer) Ext(path string) string {
 	return Ext(UnixSeparator, path)
 }
 
 // FromSlash implements Renderer.
-func (unixRenderer) FromSlash(path string) string {
+func (UnixRenderer) FromSlash(path string) string {
 	return FromSlash(UnixSeparator, path)
 }
 
 // IsAbs implements Renderer.
-func (unixRenderer) IsAbs(path string) bool {
+func (UnixRenderer) IsAbs(path string) bool {
 	return strings.HasPrefix(path, string(UnixSeparator))
 }
 
 // Join implements Renderer.
-func (ur unixRenderer) Join(path ...string) string {
+func (ur UnixRenderer) Join(path ...string) string {
 	return Join(UnixSeparator, ur.VolumeName, path...)
 }
 
 // Match implements Renderer.
-func (unixRenderer) Match(pattern, name string) (matched bool, err error) {
+func (UnixRenderer) Match(pattern, name string) (matched bool, err error) {
 	return Match(UnixSeparator, pattern, name)
 }
 
 // Split implements Renderer.
-func (ur unixRenderer) Split(path string) (dir, file string) {
+func (ur UnixRenderer) Split(path string) (dir, file string) {
 	return Split(UnixSeparator, ur.VolumeName, path)
 }
 
 // SplitList implements Renderer.
-func (unixRenderer) SplitList(path string) []string {
+func (UnixRenderer) SplitList(path string) []string {
 	if path == "" {
 		return []string{}
 	}
@@ -70,11 +71,11 @@ func (unixRenderer) SplitList(path string) []string {
 }
 
 // ToSlash implements Renderer.
-func (unixRenderer) ToSlash(path string) string {
+func (UnixRenderer) ToSlash(path string) string {
 	return ToSlash(UnixSeparator, path)
 }
 
 // VolumeName implements Renderer.
-func (unixRenderer) VolumeName(path string) string {
+func (UnixRenderer) VolumeName(path string) string {
 	return ""
 }

--- a/filepath/unix.go
+++ b/filepath/unix.go
@@ -1,0 +1,80 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filepath
+
+import (
+	"strings"
+)
+
+// A substantial portion of this code comes from the Go stdlib code.
+
+const (
+	UnixSeparator     = '/' // OS-specific path separator
+	UnixListSeparator = ':' // OS-specific path list separator
+)
+
+type unixRenderer struct{}
+
+// Base implements Renderer.
+func (ur unixRenderer) Base(path string) string {
+	return Base(UnixSeparator, ur.VolumeName, path)
+}
+
+// Clean implements Renderer.
+func (ur unixRenderer) Clean(path string) string {
+	return Clean(UnixSeparator, ur.VolumeName, path)
+}
+
+// Dir implements Renderer.
+func (ur unixRenderer) Dir(path string) string {
+	return Dir(UnixSeparator, ur.VolumeName, path)
+}
+
+// Ext implements Renderer.
+func (unixRenderer) Ext(path string) string {
+	return Ext(UnixSeparator, path)
+}
+
+// FromSlash implements Renderer.
+func (unixRenderer) FromSlash(path string) string {
+	return FromSlash(UnixSeparator, path)
+}
+
+// IsAbs implements Renderer.
+func (unixRenderer) IsAbs(path string) bool {
+	return strings.HasPrefix(path, string(UnixSeparator))
+}
+
+// Join implements Renderer.
+func (ur unixRenderer) Join(path ...string) string {
+	return Join(UnixSeparator, ur.VolumeName, path...)
+}
+
+// Match implements Renderer.
+func (unixRenderer) Match(pattern, name string) (matched bool, err error) {
+	return Match(UnixSeparator, pattern, name)
+}
+
+// Split implements Renderer.
+func (ur unixRenderer) Split(path string) (dir, file string) {
+	return Split(UnixSeparator, ur.VolumeName, path)
+}
+
+// SplitList implements Renderer.
+func (unixRenderer) SplitList(path string) []string {
+	if path == "" {
+		return []string{}
+	}
+	return strings.Split(path, string(UnixListSeparator))
+}
+
+// ToSlash implements Renderer.
+func (unixRenderer) ToSlash(path string) string {
+	return ToSlash(UnixSeparator, path)
+}
+
+// VolumeName implements Renderer.
+func (unixRenderer) VolumeName(path string) string {
+	return ""
+}

--- a/filepath/unix_test.go
+++ b/filepath/unix_test.go
@@ -1,0 +1,226 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filepath_test
+
+import (
+	gofilepath "path/filepath"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils/filepath"
+)
+
+var _ = gc.Suite(&unixSuite{})
+var _ = gc.Suite(&unixThinWrapperSuite{})
+
+type unixBaseSuite struct {
+	testing.IsolationSuite
+
+	path     string
+	renderer *filepath.UnixRenderer
+}
+
+func (s *unixBaseSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.path = "/a/b/c.xyz"
+	s.renderer = &filepath.UnixRenderer{}
+}
+
+func (s *unixBaseSuite) matchesRuntime() bool {
+	return gofilepath.Separator == filepath.UnixSeparator
+}
+
+type unixSuite struct {
+	unixBaseSuite
+}
+
+func (s unixSuite) TestIsAbs(c *gc.C) {
+	isAbs := s.renderer.IsAbs(s.path)
+
+	c.Check(isAbs, jc.IsTrue)
+	if s.matchesRuntime() {
+		c.Check(isAbs, gc.Equals, gofilepath.IsAbs(s.path))
+	}
+}
+
+func (s unixSuite) TestSplitList(c *gc.C) {
+	list := s.renderer.SplitList("/a:b:/c/d")
+
+	c.Check(list, jc.DeepEquals, []string{"/a", "b", "/c/d"})
+	if s.matchesRuntime() {
+		golist := gofilepath.SplitList("/a:b:/c/d")
+		c.Check(list, jc.DeepEquals, golist)
+	}
+}
+
+func (s unixSuite) TestVolumeName(c *gc.C) {
+	volumeName := s.renderer.VolumeName(s.path)
+
+	c.Check(volumeName, gc.Equals, "")
+}
+
+// unixThinWrapperSuite contains test methods for UnixRenderer methods
+// that are just thin wrappers around the corresponding helpers in the
+// filepath package. As such the test coverage is minimal (more of a
+// sanity check).
+type unixThinWrapperSuite struct {
+	unixBaseSuite
+}
+
+func (s unixThinWrapperSuite) TestBase(c *gc.C) {
+	path := s.renderer.Base(s.path)
+
+	c.Check(path, gc.Equals, "c.xyz")
+	if s.matchesRuntime() {
+		gopath := gofilepath.Base(s.path)
+		c.Check(path, gc.Equals, gopath)
+	}
+}
+
+func (s unixThinWrapperSuite) TestClean(c *gc.C) {
+	// TODO(ericsnow) Add more cases.
+	originals := map[string]string{
+		s.path: s.path,
+	}
+	for original, expected := range originals {
+		c.Logf("checking %q", original)
+		path := s.renderer.Clean(original)
+
+		c.Check(path, gc.Equals, expected)
+		if s.matchesRuntime() {
+			gopath := gofilepath.Clean(original)
+			c.Check(path, gc.Equals, gopath)
+		}
+	}
+}
+
+func (s unixThinWrapperSuite) TestDir(c *gc.C) {
+	path := s.renderer.Dir(s.path)
+
+	c.Check(path, gc.Equals, "/a/b")
+	if s.matchesRuntime() {
+		gopath := gofilepath.Dir(s.path)
+		c.Check(path, gc.Equals, gopath)
+	}
+}
+
+func (s unixThinWrapperSuite) TestExt(c *gc.C) {
+	ext := s.renderer.Ext(s.path)
+
+	c.Check(ext, gc.Equals, ".xyz")
+	if s.matchesRuntime() {
+		goext := gofilepath.Ext(s.path)
+		c.Check(ext, gc.Equals, goext)
+	}
+}
+
+func (s unixThinWrapperSuite) TestFromSlash(c *gc.C) {
+	original := "/a/b/c.xyz"
+	path := s.renderer.FromSlash(original)
+
+	c.Check(path, gc.Equals, s.path)
+	if s.matchesRuntime() {
+		gopath := gofilepath.FromSlash(original)
+		c.Check(path, gc.Equals, gopath)
+	}
+}
+
+func (s unixThinWrapperSuite) TestJoin(c *gc.C) {
+	path := s.renderer.Join("a", "b", "c.xyz")
+
+	c.Check(path, gc.Equals, s.path[1:])
+	if s.matchesRuntime() {
+		gopath := gofilepath.Join("a", "b", "c.xyz")
+		c.Check(path, gc.Equals, gopath)
+	}
+}
+
+func (s unixThinWrapperSuite) TestSplit(c *gc.C) {
+	dir, base := s.renderer.Split(s.path)
+
+	c.Check(dir, gc.Equals, "/a/b/")
+	c.Check(base, gc.Equals, "c.xyz")
+	if s.matchesRuntime() {
+		godir, gobase := gofilepath.Split(s.path)
+		c.Check(dir, gc.Equals, godir)
+		c.Check(base, gc.Equals, gobase)
+	}
+}
+
+func (s unixThinWrapperSuite) TestToSlash(c *gc.C) {
+	path := s.renderer.ToSlash(s.path)
+
+	c.Check(path, gc.Equals, "/a/b/c.xyz")
+	if s.matchesRuntime() {
+		gopath := gofilepath.ToSlash(s.path)
+		c.Check(path, gc.Equals, gopath)
+	}
+}
+
+func (s unixThinWrapperSuite) TestMatchTrue(c *gc.C) {
+	tests := map[string]string{
+		"abc":   "abc",
+		"ab[c]": "abc",
+		"":      "",
+		"*":     "abc",
+		"a*c":   "abc",
+		"?":     "a",
+		"a?c":   "abc",
+	}
+	for pattern, name := range tests {
+		c.Logf("- checking pattern %q against %q -", pattern, name)
+		matched, err := s.renderer.Match(pattern, name)
+		c.Assert(err, jc.ErrorIsNil)
+
+		c.Check(matched, jc.IsTrue)
+		if s.matchesRuntime() {
+			gomatched, err := gofilepath.Match(pattern, name)
+			c.Assert(err, jc.ErrorIsNil)
+			c.Check(matched, gc.Equals, gomatched)
+		}
+	}
+}
+
+func (s unixThinWrapperSuite) TestMatchFalse(c *gc.C) {
+	tests := map[string]string{
+		"abc": "xyz",
+		"":    "abc",
+		"a*c": "a",
+		"?":   "",
+		"a?c": "ac",
+	}
+	for pattern, name := range tests {
+		c.Logf("- checking pattern %q against %q -", pattern, name)
+		matched, err := s.renderer.Match(pattern, name)
+		c.Assert(err, jc.ErrorIsNil)
+
+		c.Check(matched, jc.IsFalse)
+		if s.matchesRuntime() {
+			gomatched, err := gofilepath.Match(pattern, name)
+			c.Assert(err, jc.ErrorIsNil)
+			c.Check(matched, gc.Equals, gomatched)
+		}
+	}
+}
+
+func (s unixThinWrapperSuite) TestMatchBadPattern(c *gc.C) {
+	tests := map[string]string{
+		"ab[":    "abc",
+		"ab[-c]": "abc",
+		"ab[]":   "abc",
+	}
+	for pattern, name := range tests {
+		c.Logf("- checking pattern %q against %q -", pattern, name)
+		_, err := s.renderer.Match(pattern, name)
+
+		c.Check(err, gc.Equals, gofilepath.ErrBadPattern)
+		if s.matchesRuntime() {
+			_, goerr := gofilepath.Match(pattern, name)
+			c.Check(err, gc.Equals, goerr)
+		}
+	}
+}

--- a/filepath/win.go
+++ b/filepath/win.go
@@ -14,35 +14,36 @@ const (
 	WindowsListSeparator = ';'  // OS-specific path list separator
 )
 
-type windowsRenderer struct{}
+// WindowsRenderer is a Renderer implementation for Windows.
+type WindowsRenderer struct{}
 
 // Base implements Renderer.
-func (ur windowsRenderer) Base(path string) string {
+func (ur WindowsRenderer) Base(path string) string {
 	return Base(WindowsSeparator, ur.VolumeName, path)
 }
 
 // Clean implements Renderer.
-func (ur windowsRenderer) Clean(path string) string {
+func (ur WindowsRenderer) Clean(path string) string {
 	return Clean(WindowsSeparator, ur.VolumeName, path)
 }
 
 // Dir implements Renderer.
-func (ur windowsRenderer) Dir(path string) string {
+func (ur WindowsRenderer) Dir(path string) string {
 	return Dir(WindowsSeparator, ur.VolumeName, path)
 }
 
 // Ext implements Renderer.
-func (windowsRenderer) Ext(path string) string {
+func (WindowsRenderer) Ext(path string) string {
 	return Ext(WindowsSeparator, path)
 }
 
 // FromSlash implements Renderer.
-func (windowsRenderer) FromSlash(path string) string {
+func (WindowsRenderer) FromSlash(path string) string {
 	return FromSlash(WindowsSeparator, path)
 }
 
 // IsAbs implements Renderer.
-func (windowsRenderer) IsAbs(path string) bool {
+func (WindowsRenderer) IsAbs(path string) bool {
 	l := volumeNameLen(path)
 	if l == 0 {
 		return false
@@ -55,22 +56,22 @@ func (windowsRenderer) IsAbs(path string) bool {
 }
 
 // Join implements Renderer.
-func (ur windowsRenderer) Join(path ...string) string {
+func (ur WindowsRenderer) Join(path ...string) string {
 	return Join(WindowsSeparator, ur.VolumeName, path...)
 }
 
 // Match implements Renderer.
-func (windowsRenderer) Match(pattern, name string) (matched bool, err error) {
+func (WindowsRenderer) Match(pattern, name string) (matched bool, err error) {
 	return Match(WindowsSeparator, pattern, name)
 }
 
 // Split implements Renderer.
-func (ur windowsRenderer) Split(path string) (dir, file string) {
+func (ur WindowsRenderer) Split(path string) (dir, file string) {
 	return Split(WindowsSeparator, ur.VolumeName, path)
 }
 
 // SplitList implements Renderer.
-func (windowsRenderer) SplitList(path string) []string {
+func (WindowsRenderer) SplitList(path string) []string {
 	if path == "" {
 		return []string{}
 	}
@@ -101,12 +102,12 @@ func (windowsRenderer) SplitList(path string) []string {
 }
 
 // ToSlash implements Renderer.
-func (windowsRenderer) ToSlash(path string) string {
+func (WindowsRenderer) ToSlash(path string) string {
 	return ToSlash(WindowsSeparator, path)
 }
 
 // VolumeName implements Renderer.
-func (windowsRenderer) VolumeName(path string) string {
+func (WindowsRenderer) VolumeName(path string) string {
 	return path[:volumeNameLen(path)]
 }
 

--- a/filepath/win.go
+++ b/filepath/win.go
@@ -1,0 +1,153 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filepath
+
+import (
+	"strings"
+)
+
+// A substantial portion of this code comes from the Go stdlib code.
+
+const (
+	WindowsSeparator     = '\\' // OS-specific path separator
+	WindowsListSeparator = ';'  // OS-specific path list separator
+)
+
+type windowsRenderer struct{}
+
+// Base implements Renderer.
+func (ur windowsRenderer) Base(path string) string {
+	return Base(WindowsSeparator, ur.VolumeName, path)
+}
+
+// Clean implements Renderer.
+func (ur windowsRenderer) Clean(path string) string {
+	return Clean(WindowsSeparator, ur.VolumeName, path)
+}
+
+// Dir implements Renderer.
+func (ur windowsRenderer) Dir(path string) string {
+	return Dir(WindowsSeparator, ur.VolumeName, path)
+}
+
+// Ext implements Renderer.
+func (windowsRenderer) Ext(path string) string {
+	return Ext(WindowsSeparator, path)
+}
+
+// FromSlash implements Renderer.
+func (windowsRenderer) FromSlash(path string) string {
+	return FromSlash(WindowsSeparator, path)
+}
+
+// IsAbs implements Renderer.
+func (windowsRenderer) IsAbs(path string) bool {
+	l := volumeNameLen(path)
+	if l == 0 {
+		return false
+	}
+	path = path[l:]
+	if path == "" {
+		return false
+	}
+	return isSlash(path[0])
+}
+
+// Join implements Renderer.
+func (ur windowsRenderer) Join(path ...string) string {
+	return Join(WindowsSeparator, ur.VolumeName, path...)
+}
+
+// Match implements Renderer.
+func (windowsRenderer) Match(pattern, name string) (matched bool, err error) {
+	return Match(WindowsSeparator, pattern, name)
+}
+
+// Split implements Renderer.
+func (ur windowsRenderer) Split(path string) (dir, file string) {
+	return Split(WindowsSeparator, ur.VolumeName, path)
+}
+
+// SplitList implements Renderer.
+func (windowsRenderer) SplitList(path string) []string {
+	if path == "" {
+		return []string{}
+	}
+
+	// Split path, respecting but preserving quotes.
+	list := []string{}
+	start := 0
+	quo := false
+	for i := 0; i < len(path); i++ {
+		switch c := path[i]; {
+		case c == '"':
+			quo = !quo
+		case c == WindowsListSeparator && !quo:
+			list = append(list, path[start:i])
+			start = i + 1
+		}
+	}
+	list = append(list, path[start:])
+
+	// Remove quotes.
+	for i, s := range list {
+		if strings.Contains(s, `"`) {
+			list[i] = strings.Replace(s, `"`, ``, -1)
+		}
+	}
+
+	return list
+}
+
+// ToSlash implements Renderer.
+func (windowsRenderer) ToSlash(path string) string {
+	return ToSlash(WindowsSeparator, path)
+}
+
+// VolumeName implements Renderer.
+func (windowsRenderer) VolumeName(path string) string {
+	return path[:volumeNameLen(path)]
+}
+
+func isSlash(c uint8) bool {
+	return c == WindowsSeparator || c == '/'
+}
+
+// volumeNameLen returns length of the leading volume name on Windows.
+// It returns 0 elsewhere.
+func volumeNameLen(path string) int {
+	if len(path) < 2 {
+		return 0
+	}
+	// with drive letter
+	c := path[0]
+	if path[1] == ':' && ('a' <= c && c <= 'z' || 'A' <= c && c <= 'Z') {
+		return 2
+	}
+	// is it UNC
+	if l := len(path); l >= 5 && isSlash(path[0]) && isSlash(path[1]) &&
+		!isSlash(path[2]) && path[2] != '.' {
+		// first, leading `\\` and next shouldn't be `\`. its server name.
+		for n := 3; n < l-1; n++ {
+			// second, next '\' shouldn't be repeated.
+			if isSlash(path[n]) {
+				n++
+				// third, following something characters. its share name.
+				if !isSlash(path[n]) {
+					if path[n] == '.' {
+						break
+					}
+					for ; n < l; n++ {
+						if isSlash(path[n]) {
+							break
+						}
+					}
+					return n
+				}
+				break
+			}
+		}
+	}
+	return 0
+}

--- a/filepath/win_test.go
+++ b/filepath/win_test.go
@@ -1,0 +1,230 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filepath_test
+
+import (
+	gofilepath "path/filepath"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils/filepath"
+)
+
+var _ = gc.Suite(&windowsSuite{})
+var _ = gc.Suite(&windowsThinWrapperSuite{})
+
+type windowsBaseSuite struct {
+	testing.IsolationSuite
+
+	path     string
+	renderer *filepath.WindowsRenderer
+}
+
+func (s *windowsBaseSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.path = `c:\a\b\c.xyz`
+	s.renderer = &filepath.WindowsRenderer{}
+}
+
+func (s *windowsBaseSuite) matchesRuntime() bool {
+	return gofilepath.Separator == filepath.WindowsSeparator
+}
+
+type windowsSuite struct {
+	windowsBaseSuite
+}
+
+func (s windowsSuite) TestIsAbs(c *gc.C) {
+	isAbs := s.renderer.IsAbs(s.path)
+
+	c.Check(isAbs, jc.IsTrue)
+	if s.matchesRuntime() {
+		c.Check(isAbs, gc.Equals, gofilepath.IsAbs(s.path))
+	}
+}
+
+func (s windowsSuite) TestSplitList(c *gc.C) {
+	list := s.renderer.SplitList(`\a;b;\c\d`)
+
+	c.Check(list, jc.DeepEquals, []string{`\a`, "b", `\c\d`})
+	if s.matchesRuntime() {
+		golist := gofilepath.SplitList(`\a;b;\c\d`)
+		c.Check(list, jc.DeepEquals, golist)
+	}
+}
+
+func (s windowsSuite) TestVolumeName(c *gc.C) {
+	volumeName := s.renderer.VolumeName(s.path)
+
+	c.Check(volumeName, gc.Equals, "c:")
+	if s.matchesRuntime() {
+		goresult := gofilepath.VolumeName(s.path)
+		c.Check(volumeName, gc.Equals, goresult)
+	}
+}
+
+// windowsThinWrapperSuite contains test methods for WindowsRenderer methods
+// that are just thin wrappers around the corresponding helpers in the
+// filepath package. As such the test coverage is minimal (more of a
+// sanity check).
+type windowsThinWrapperSuite struct {
+	windowsBaseSuite
+}
+
+func (s windowsThinWrapperSuite) TestBase(c *gc.C) {
+	path := s.renderer.Base(s.path)
+
+	c.Check(path, gc.Equals, "c.xyz")
+	if s.matchesRuntime() {
+		gopath := gofilepath.Base(s.path)
+		c.Check(path, gc.Equals, gopath)
+	}
+}
+
+func (s windowsThinWrapperSuite) TestClean(c *gc.C) {
+	// TODO(ericsnow) Add more cases.
+	originals := map[string]string{
+		s.path: s.path,
+	}
+	for original, expected := range originals {
+		c.Logf("checking %q", original)
+		path := s.renderer.Clean(original)
+
+		c.Check(path, gc.Equals, expected)
+		if s.matchesRuntime() {
+			gopath := gofilepath.Clean(original)
+			c.Check(path, gc.Equals, gopath)
+		}
+	}
+}
+
+func (s windowsThinWrapperSuite) TestDir(c *gc.C) {
+	path := s.renderer.Dir(s.path)
+
+	c.Check(path, gc.Equals, `c:\a\b`)
+	if s.matchesRuntime() {
+		gopath := gofilepath.Dir(s.path)
+		c.Check(path, gc.Equals, gopath)
+	}
+}
+
+func (s windowsThinWrapperSuite) TestExt(c *gc.C) {
+	ext := s.renderer.Ext(s.path)
+
+	c.Check(ext, gc.Equals, ".xyz")
+	if s.matchesRuntime() {
+		goext := gofilepath.Ext(s.path)
+		c.Check(ext, gc.Equals, goext)
+	}
+}
+
+func (s windowsThinWrapperSuite) TestFromSlash(c *gc.C) {
+	original := "/a/b/c.xyz"
+	path := s.renderer.FromSlash(original)
+
+	c.Check(path, gc.Equals, s.path[2:])
+	if s.matchesRuntime() {
+		gopath := gofilepath.FromSlash(original)
+		c.Check(path, gc.Equals, gopath)
+	}
+}
+
+func (s windowsThinWrapperSuite) TestJoin(c *gc.C) {
+	path := s.renderer.Join("a", "b", "c.xyz")
+
+	c.Check(path, gc.Equals, s.path[3:])
+	if s.matchesRuntime() {
+		gopath := gofilepath.Join("a", "b", "c.xyz")
+		c.Check(path, gc.Equals, gopath)
+	}
+}
+
+func (s windowsThinWrapperSuite) TestSplit(c *gc.C) {
+	dir, base := s.renderer.Split(s.path)
+
+	c.Check(dir, gc.Equals, `c:\a\b\`)
+	c.Check(base, gc.Equals, "c.xyz")
+	if s.matchesRuntime() {
+		godir, gobase := gofilepath.Split(s.path)
+		c.Check(dir, gc.Equals, godir)
+		c.Check(base, gc.Equals, gobase)
+	}
+}
+
+func (s windowsThinWrapperSuite) TestToSlash(c *gc.C) {
+	path := s.renderer.ToSlash(s.path)
+
+	c.Check(path, gc.Equals, "c:/a/b/c.xyz")
+	if s.matchesRuntime() {
+		gopath := gofilepath.ToSlash(s.path)
+		c.Check(path, gc.Equals, gopath)
+	}
+}
+
+func (s windowsThinWrapperSuite) TestMatchTrue(c *gc.C) {
+	tests := map[string]string{
+		"abc":   "abc",
+		"ab[c]": "abc",
+		"":      "",
+		"*":     "abc",
+		"a*c":   "abc",
+		"?":     "a",
+		"a?c":   "abc",
+	}
+	for pattern, name := range tests {
+		c.Logf("- checking pattern %q against %q -", pattern, name)
+		matched, err := s.renderer.Match(pattern, name)
+		c.Assert(err, jc.ErrorIsNil)
+
+		c.Check(matched, jc.IsTrue)
+		if s.matchesRuntime() {
+			gomatched, err := gofilepath.Match(pattern, name)
+			c.Assert(err, jc.ErrorIsNil)
+			c.Check(matched, gc.Equals, gomatched)
+		}
+	}
+}
+
+func (s windowsThinWrapperSuite) TestMatchFalse(c *gc.C) {
+	tests := map[string]string{
+		"abc": "xyz",
+		"":    "abc",
+		"a*c": "a",
+		"?":   "",
+		"a?c": "ac",
+	}
+	for pattern, name := range tests {
+		c.Logf("- checking pattern %q against %q -", pattern, name)
+		matched, err := s.renderer.Match(pattern, name)
+		c.Assert(err, jc.ErrorIsNil)
+
+		c.Check(matched, jc.IsFalse)
+		if s.matchesRuntime() {
+			gomatched, err := gofilepath.Match(pattern, name)
+			c.Assert(err, jc.ErrorIsNil)
+			c.Check(matched, gc.Equals, gomatched)
+		}
+	}
+}
+
+func (s windowsThinWrapperSuite) TestMatchBadPattern(c *gc.C) {
+	tests := map[string]string{
+		"ab[":    "abc",
+		"ab[-c]": "abc",
+		"ab[]":   "abc",
+	}
+	for pattern, name := range tests {
+		c.Logf("- checking pattern %q against %q -", pattern, name)
+		_, err := s.renderer.Match(pattern, name)
+
+		c.Check(err, gc.Equals, gofilepath.ErrBadPattern)
+		if s.matchesRuntime() {
+			_, goerr := gofilepath.Match(pattern, name)
+			c.Check(err, gc.Equals, goerr)
+		}
+	}
+}

--- a/os.go
+++ b/os.go
@@ -1,0 +1,41 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils
+
+// These are the names of the operating systems recognized by Go.
+const (
+	OSWindows   = "windows"
+	OSDarwin    = "darwin"
+	OSDragonfly = "dragonfly"
+	OSFreebsd   = "freebsd"
+	OSLinux     = "linux"
+	OSNacl      = "nacl"
+	OSNetbsd    = "netbsd"
+	OSOpenbsd   = "openbsd"
+	OSSolaris   = "solaris"
+)
+
+// OSUnix is the list of unix-like operating systems recognized by Go.
+// See http://golang.org/src/path/filepath/path_unix.go.
+var OSUnix = []string{
+	OSDarwin,
+	OSDragonfly,
+	OSFreebsd,
+	OSLinux,
+	OSNacl,
+	OSNetbsd,
+	OSOpenbsd,
+	OSSolaris,
+}
+
+// OSIsUnix determines whether or not the given OS name is one of the
+// unix-like operating systems recognized by Go.
+func OSIsUnix(os string) bool {
+	for _, goos := range OSUnix {
+		if os == goos {
+			return true
+		}
+	}
+	return false
+}

--- a/os_test.go
+++ b/os_test.go
@@ -1,0 +1,39 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package utils_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils"
+)
+
+var _ = gc.Suite(&osSuite{})
+
+type osSuite struct {
+	testing.IsolationSuite
+}
+
+func (osSuite) TestOSIsUnixKnown(c *gc.C) {
+	for _, os := range utils.OSUnix {
+		c.Logf("checking %q", os)
+		isUnix := utils.OSIsUnix(os)
+
+		c.Check(isUnix, jc.IsTrue)
+	}
+}
+
+func (osSuite) TestOSIsUnixWindows(c *gc.C) {
+	isUnix := utils.OSIsUnix("windows")
+
+	c.Check(isUnix, jc.IsFalse)
+}
+
+func (osSuite) TestOSIsUnixUnknown(c *gc.C) {
+	isUnix := utils.OSIsUnix("<unknown OS>")
+
+	c.Check(isUnix, jc.IsFalse)
+}


### PR DESCRIPTION
We use the functionality provided by the stdlib path/filepath package throughout juju to great effect.  The problem is that those functions are tied to the current operating system (runtime.GOOS).  There are cases where we want to use those same functions but targeting some other OS.  This patch facilitates such functionality via:

 * a set of helper functions for most of the path/filepath functions which take a path separator argument;
 * a new Renderer interface that exposes all the functions in path/filepath that don't relate to a concrete filesystem;
 * an implementation of Renderer for unix-like OSes and for Windows, both of which are almost entirely light wrappers around the separator-based helper functions;
 * a NewRenderer factory function that gives you the right Renderer implementation based on the OS name you give it;
 * all this is located in a package called "filepath".

The implementation of the helper functions (in stdlib*.go) is almost entirely copied from the Go stdlib source code.  The only difference is that hard-coded path separators have been changed to use the separator argument.  It's unfortunate that we have to copy-and-paste code like this, but there aren't any better alternatives.

(Review request: http://reviews.vapour.ws/r/1162/)