### PR TITLE
Modify LICENSE to include copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,6 @@
+This package provides general utility packages and functions.
+Copyright (C) 2011-2015 Canonical Ltd.
+
 This software is licensed under the LGPLv3, included below.
 
 As a special exception to the GNU Lesser General Public License version 3


### PR DESCRIPTION
Some files in the repo don't have copyright notice provided.
We may deal with it by providing 'default' copyright which points to the main contributor (Canonical).

This has been done for some other subprojects already:
https://github.com/juju/txn/commit/2ada94b483ac8d579e1e23a54f16c60d4b78e5f9
https://github.com/juju/cmd/commit/e30c3dd7434e910ecbdf69518e9abe6e827a999d