### PR TITLE
Fix the Go LICENCE file.

### DIFF
--- a/LICENSE.golang
+++ b/LICENSE.golang
@@ -1,3 +1,8 @@
+This licence applies to the following files:
+
+* filepath/stdlib.go
+* filepath/stdlibmatch.go
+
 Copyright (c) 2010 The Go Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/filepath/stdlib.go
+++ b/filepath/stdlib.go
@@ -2,7 +2,7 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE.Go file.
+// license that can be found in the LICENSE.golang file.
 
 package filepath
 

--- a/filepath/stdlibmatch.go
+++ b/filepath/stdlibmatch.go
@@ -2,7 +2,7 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE.Go file.
+// license that can be found in the LICENSE.golang file.
 
 package filepath
 


### PR DESCRIPTION
This includes renaming the file so that it doesn't get compiled as a .go file on Windows (and other case-insensitive languages).

(Review request: http://reviews.vapour.ws/r/1301/)