### PR TITLE
Fixed spacing issue

### DIFF
--- a/packaging/config/global_constants.go
+++ b/packaging/config/global_constants.go
@@ -18,12 +18,13 @@ function package_manager_loop {
                 rc=$?
         fi
         if [ $rc -eq 100 ]; then
-		sleep 10s
+                sleep 10s
                 continue
         fi
         return $rc
-	done
-}`
+    done
+}
+`
 )
 
 var (


### PR DESCRIPTION
Am amazingly interesting fix.

Bash doesn't seem to like the old whitespace formatting.

(Review request: http://reviews.vapour.ws/r/1474/)