### PR TITLE
Added securestring package.

### DIFF
--- a/securestring/securestring.go
+++ b/securestring/securestring.go
@@ -1,0 +1,161 @@
+// Copyright 2015 Canonical Ltd.
+// Copyright 2015 Cloudbase Solutions SRL.
+// Licensed under the AGPLv3, see LICENCE file for details.
+//
+// +build windows
+
+package securestring
+
+import (
+	"encoding/hex"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"github.com/juju/errors"
+)
+
+var (
+	cryptdll  = syscall.NewLazyDLL("Crypt32.dll")
+	kerneldll = syscall.NewLazyDLL("Kernel32.dll")
+
+	// Syntax:
+	// procProtectData.Call(inputBlob *blob, dataDescription *string,
+	//		optionalEntropy *blob, freeWorkingSpace *void, proptStruct
+	//		*CRYPTPROTECT_PROMPTSTRUCT, dwflags uint, outputBlob *blob)
+	//
+	// Parameters:
+	// In the calls made by the ConvertFrom-SecureString commandlet;
+	// dataDescription, optionalEntropy, freeWorkingSpace and proptStruct
+	// are set to their respective zero values.
+	//
+	// inputBlob contains the actual input, outputBlob is set to its zero
+	// value, and dwflags is set to the default of 1.
+	//
+	// Return value:
+	// A C-boolean; 1(true) if it succeeds, 0(false) if it fails
+	procProtectData = cryptdll.NewProc("CryptProtectData")
+
+	// Syntax:
+	// procUnprotectData.Call(inputBlob *blob, dataDescription *string,
+	//		optionalEntropy *blob, freeWorkingSpace *void, proptStruct
+	//		*CRYPTPROTECT_PROMPTSTRUCT, dwflags uint, outputBlob *blob)
+	//
+	// Parameters:
+	// In our case; dataDescription, optionalEntropy, freeWorkingSpace and
+	// proptStruct are set to their respective zero values.
+	// inputBlob contains the actual input, outputBlob is set to its zero
+	// value, and dwflags is set to the default of 1.
+	//
+	// Return value:
+	// A C-boolean; 1(true) if it succeeds, 0(false) if it fails.
+	procUnprotectData = cryptdll.NewProc("CryptUnprotectData")
+
+	// Syntax:
+	// procLocalFree.Call(ptr *uint)
+	//
+	// Parameter:
+	// An unsafe pointer of any type, for our purposes a *uint.
+	//
+	// Return value:
+	// Pointer value. nil if it succeeds, ptr if it fails.
+	procLocalFree = kerneldll.NewProc("LocalFree")
+)
+
+// blob is the struct type we shall be making the syscalls on. It contains a
+// pointer to the start of the actual data and its respective length in bytes.
+type blob struct {
+	length uint32
+	data   *byte
+}
+
+// getData is a helper method which fetches all the data pointed to by blob.data.
+func (b *blob) getData() []byte {
+	var fetched = make([]byte, b.length)
+
+	// The built-in will copy the proper amount of data pointed to by blob.data
+	// and put it in the new variable.
+	// 1 << 30 is the largest possible slice size; it's pretty overkill but it
+	// ensures we can read as most of very large data as physically possible.
+	copy(fetched, (*[1 << 30]byte)(unsafe.Pointer(b.data))[:])
+
+	return fetched
+}
+
+// Encrypt encrypts a provided string as input into a hexadecimal string.
+// The output corresponds to the output of ConvertFrom-SecureString:
+func Encrypt(input string) (string, error) {
+	data := []byte(input)
+
+	// For some reason; the cmdlet's calls automatically encrypts the bytes
+	// with interwoven null characters, so we must account for this as follows:
+	nulled := []byte{}
+	for _, b := range data {
+		nulled = append(nulled, b)
+		nulled = append(nulled, 0)
+	}
+
+	inputBlob := blob{uint32(len(nulled)), &nulled[0]}
+	entropyBlob := blob{}
+	outputBlob := blob{}
+	dwflags := 1
+
+	res, _, err := procProtectData.Call(uintptr(unsafe.Pointer(&inputBlob)),
+		uintptr(0), uintptr(unsafe.Pointer(&entropyBlob)), uintptr(0),
+		uintptr(0), uintptr(uint(dwflags)),
+		uintptr(unsafe.Pointer(&outputBlob)))
+	defer procLocalFree.Call(uintptr(unsafe.Pointer(outputBlob.data)))
+
+	// check if result is 0 (C's false).
+	if res == 0 {
+		return "", errors.Trace(err)
+	}
+
+	output := outputBlob.getData()
+
+	// The result is a slice of bytes, which we must encode into hexa
+	// to match ConvertFrom-SecureString's output before returning it.
+	return hex.EncodeToString(output), nil
+}
+
+// Decrypt converts the output from a call to ConvertFrom-SecureString
+// back to the original input string and returns it.
+func Decrypt(input string) (string, error) {
+	// Trim spaces preemptively here.
+	trimmed := strings.TrimSpace(input)
+
+	// First we decode the hexadecimal string into a raw slice of bytes.
+	data, err := hex.DecodeString(trimmed)
+	if err != nil {
+		return "", err
+	}
+
+	inputBlob := blob{uint32(len(data)), &data[0]}
+	entropyBlob := blob{}
+	outputBlob := blob{}
+	dwflags := 1
+
+	res, _, err := procUnprotectData.Call(uintptr(unsafe.Pointer(&inputBlob)),
+		uintptr(0), uintptr(unsafe.Pointer(&entropyBlob)), uintptr(0),
+		uintptr(0), uintptr(uint(dwflags)),
+		uintptr(unsafe.Pointer(&outputBlob)))
+	defer procLocalFree.Call(uintptr(unsafe.Pointer(outputBlob.data)))
+
+	// Check is result is 0 (C's false).
+	if res == 0 {
+		return "", errors.Trace(err)
+	}
+
+	output := outputBlob.getData()
+
+	// As mentioned, the cmdlets infer working with data with interwoven
+	// null characters, for which we must account for by removing them now:
+	clean := []byte{}
+	for _, b := range output {
+		if b != 0 {
+			clean = append(clean, b)
+		}
+	}
+
+	return string(clean), nil
+}

--- a/securestring/securestring_test.go
+++ b/securestring/securestring_test.go
@@ -1,0 +1,108 @@
+// Copyright 2015 Canonical Ltd.
+// Copyright 2015 Cloudbase Solutions SRL.
+// Licensed under the AGPLv3, see LICENCE file for details.
+//
+// +build windows
+
+package securestring_test
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	gss "github.com/juju/utils/securestring"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}
+
+type SecureStringSuite struct{}
+
+var _ = gc.Suite(&SecureStringSuite{})
+
+// testInputs is the set of inputs we will be using in our tests.
+var testInputs []string = []string{
+	"Simple",
+	"A longer string",
+	"A!string%with(a4239lot#of$&*special@characters{[]})",
+	"Quite a very much longer string meant to push the envelope",
+	"fsdafsgdfgdfgdfgdfgsdfgdgdfgdmmghnh kv dfv dj fkvjjenrwenvfvvslfvnsljfvnlsfvlnsfjlvnssdwoewivdsvmxxvsdvsdv",
+}
+
+// TestEncryptDecryptSymmetry tests whether encryption and decryption
+// are perfectly symmetrical operations.
+func (s *SecureStringSuite) TestEncryptDecryptSymmetry(c *gc.C) {
+	for _, input := range testInputs {
+		enc, err := gss.Encrypt(input)
+		c.Assert(err, jc.ErrorIsNil)
+
+		dec, err := gss.Decrypt(enc)
+		c.Assert(err, jc.ErrorIsNil)
+
+		c.Assert(dec, gc.Equals, input)
+	}
+}
+
+// invokePowerShellParams is the standard set of parameters
+// use to invoke a PoweShell session.
+var invokePowerShellParams []string = []string{
+	"-NoProfile",
+	"-NonInteractive",
+	"-Command",
+	"try{$input|iex; exit $LastExitCode}catch{Write-Error -Message $Error[0]; exit 1}",
+}
+
+// runPowerShellCommand is a helper function which invokes a PowerShell session
+// and runs the given command.
+func runPowerShellCommands(cmds string) (string, error) {
+	ps := exec.Command("powershell.exe", invokePowerShellParams...)
+
+	ps.Stdin = strings.NewReader(cmds)
+	stdout := &bytes.Buffer{}
+	ps.Stdout = stdout
+
+	err := ps.Run()
+	if err != nil {
+		return "", err
+	}
+
+	output := string(stdout.String())
+	return strings.TrimSpace(output), nil
+}
+
+// TestDecryptFromCFSS tests whether the output of ConvertFrom-SecureString
+// is compatible with this module's Decrypt function and can be
+// succesfully decrypted.
+func (s *SecureStringSuite) TestDecryptFromCFSS(c *gc.C) {
+	for _, input := range testInputs {
+		psenc, err := runPowerShellCommands(fmt.Sprintf("ConvertTo-SecureString \"%s\" -AsPlainText -Force | ConvertFrom-SecureString", input))
+		c.Assert(err, jc.ErrorIsNil)
+
+		dec, err := gss.Decrypt(psenc)
+		c.Assert(err, jc.ErrorIsNil)
+
+		c.Assert(dec, gc.Equals, input)
+	}
+}
+
+// TestConvertEncryptedToPowerShellSS tests whether the output of the module's
+// Encrypt function is compatible with PowerShell's SecureString and is accepted
+// as valid input by being taken in as a System.Security.SecureString internal.
+func (s *SecureStringSuite) TestConvertEncryptedToPowerShellSS(c *gc.C) {
+	for _, input := range testInputs {
+		enc, err := gss.Encrypt(input)
+		c.Assert(err, jc.ErrorIsNil)
+
+		psresp, err := runPowerShellCommands(fmt.Sprintf("\"%s\" | ConvertTo-SecureString", enc))
+		c.Assert(err, jc.ErrorIsNil)
+
+		c.Assert(psresp, gc.Equals, "System.Security.SecureString")
+	}
+}


### PR DESCRIPTION
A go implementation of Windows'SecureStrings.
A pure go implementation of this will be required for the Windows services module from core.

This module mimics the functionality of the ConvertFrom-SecureString PowerShell commandlet when used in the following context:

```
PS > $ss1 = ConvertTo-SecureString "Your string" -AsPlainText -Force
PS > $ss1
System.Security.SecureString
PS > ConvertFrom-SecureString $ss1
# The above yields the encrypted string in hexadecimal form which may be passed
# to this module's Decrypt() function in order to get the original string.

# Conversely, calling the Encrypt() function will yield an output
# which is perfectly compatible with ConvertTo-SecureString:
PS > "Output of Encrypt()" | ConvertTo-SecureString | $ss2
PS > $ss2
System.Security.SecureString
```

* Additional notes:
  1. SecureStrings in Windows, in it of themselves, are nothing more than plain strings stored in memory which is completely locked.
  2. ConvertFrom-SecureString uses the DAPI encryption technique to yield a hexadecimal-encoded string which encrypts the data from the locked memory.
  3. DAPI encrypts with the current user session in mind; therefore, decrypting ConvertFrom-SecureString's output can NOT be done by a different user than that which did the encryption in the first place, be it by the PowerShell commandlets or the methods in this module !!!
  4. Because of various user session parameters being used in the encryption process, both ConvertFrom-SecureString and this module's Encrypt() function yield varying output at each call, thus comparing the outputs of two different encryptions, albeit of the same input, will fail.

* Related documentation:
  * [Crypt32.dll::CryptProtectData](http://msdn.microsoft.com/en-us/library/windows/desktop/aa380261%28v=vs.85%29.aspx)
  * [Crypt32.dll::CryptUnprotectData](http://msdn.microsoft.com/en-us/library/windows/desktop/aa380882%28v=vs.85%29.aspx)
  * [Kernel32.dll::LocalFree](http://msdn.microsoft.com/en-us/library/windows/desktop/aa366730%28v=vs.85%29.aspx)
  * [System.Security.Cryptography.CAPI::CRYPTOAPI_BLOB](http://msdn.microsoft.com/en-us/library/windows/desktop/aa381414%28v=vs.85%29.aspx)

(http://reviews.vapour.ws/r/1486/)