### PR TITLE
Add NormCase and SplitSuffix to filepath.Renderer.

### DIFF
--- a/filepath/common.go
+++ b/filepath/common.go
@@ -4,9 +4,9 @@
 package filepath
 
 func splitSuffix(path string) (string, string) {
-	for i := len(path) - 1; i >= 0; i++ {
+	for i := len(path) - 1; i >= 0; i-- {
 		if path[i] == '.' && i > 0 {
-			return path[:i-1], path[i:]
+			return path[:i], path[i:]
 		}
 	}
 	return path, ""

--- a/filepath/common.go
+++ b/filepath/common.go
@@ -1,0 +1,13 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filepath
+
+func splitSuffix(path string) (string, string) {
+	for i := len(path) - 1; i >= 0; i++ {
+		if path[i] == '.' && i > 0 {
+			return path[:i-1], path[i:]
+		}
+	}
+	return path, ""
+}

--- a/filepath/common_test.go
+++ b/filepath/common_test.go
@@ -1,0 +1,52 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filepath_test
+
+import (
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils/filepath"
+)
+
+var _ = gc.Suite(&commonSuite{})
+
+type commonSuite struct {
+	testing.IsolationSuite
+}
+
+func (s commonSuite) TestSplitSuffixHasSuffix(c *gc.C) {
+	path, suffix := filepath.SplitSuffix("spam.ext")
+
+	c.Check(path, gc.Equals, "spam")
+	c.Check(suffix, gc.Equals, ".ext")
+}
+
+func (s commonSuite) TestSplitSuffixNoSuffix(c *gc.C) {
+	path, suffix := filepath.SplitSuffix("spam")
+
+	c.Check(path, gc.Equals, "spam")
+	c.Check(suffix, gc.Equals, "")
+}
+
+func (s commonSuite) TestSplitSuffixEmpty(c *gc.C) {
+	path, suffix := filepath.SplitSuffix("")
+
+	c.Check(path, gc.Equals, "")
+	c.Check(suffix, gc.Equals, "")
+}
+
+func (s commonSuite) TestSplitSuffixDotFilePlain(c *gc.C) {
+	path, suffix := filepath.SplitSuffix(".spam")
+
+	c.Check(path, gc.Equals, ".spam")
+	c.Check(suffix, gc.Equals, "")
+}
+
+func (s commonSuite) TestSplitSuffixDofileWithSuffix(c *gc.C) {
+	path, suffix := filepath.SplitSuffix(".spam.ext")
+
+	c.Check(path, gc.Equals, ".spam")
+	c.Check(suffix, gc.Equals, ".ext")
+}

--- a/filepath/export_test.go
+++ b/filepath/export_test.go
@@ -1,0 +1,8 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package filepath
+
+var (
+	SplitSuffix = splitSuffix
+)

--- a/filepath/filepath.go
+++ b/filepath/filepath.go
@@ -52,23 +52,6 @@ type Renderer interface {
 	// Split mimics path/filepath.
 	Split(path string) (dir, file string)
 
-	// SplitDrive splits the pathname into a pair (drive, tail) where
-	// drive is either a mount point or the empty string. On systems
-	// which do not use drive specifications, drive will always be the
-	// empty string. In all cases, drive + tail will be the same as path.
-	//
-	// On Windows, splits a pathname into drive/UNC sharepoint and
-	// relative path.
-	//
-	// If the path contains a drive letter, drive will contain
-	// everything up to and including the colon. e.g.
-	// splitdrive("c:/dir") returns ("c:", "/dir")
-	//
-	// If the path contains a UNC path, drive will contain the host name
-	// and share, up to but not including the fourth separator. e.g.
-	// SplitDrive("//host/computer/dir") returns ("//host/computer", "/dir").
-	SplitDrive(path string) string
-
 	// SplitList mimics path/filepath.
 	SplitList(path string) []string
 

--- a/filepath/filepath.go
+++ b/filepath/filepath.go
@@ -45,8 +45,7 @@ type Renderer interface {
 
 	// NormCase normalizes the case of a pathname. On Unix and Mac OS X,
 	// this returns the path unchanged; on case-insensitive filesystems,
-	// it converts the path to lowercase. On Windows, it also converts
-	// forward slashes to backward slashes.
+	// it converts the path to lowercase.
 	NormCase(path string) string
 
 	// Split mimics path/filepath.

--- a/filepath/filepath.go
+++ b/filepath/filepath.go
@@ -43,11 +43,40 @@ type Renderer interface {
 	// Match mimics path/filepath.
 	Match(pattern, name string) (matched bool, err error)
 
+	// NormCase normalizes the case of a pathname. On Unix and Mac OS X,
+	// this returns the path unchanged; on case-insensitive filesystems,
+	// it converts the path to lowercase. On Windows, it also converts
+	// forward slashes to backward slashes.
+	NormCase(path string) string
+
 	// Split mimics path/filepath.
 	Split(path string) (dir, file string)
 
+	// SplitDrive splits the pathname into a pair (drive, tail) where
+	// drive is either a mount point or the empty string. On systems
+	// which do not use drive specifications, drive will always be the
+	// empty string. In all cases, drive + tail will be the same as path.
+	//
+	// On Windows, splits a pathname into drive/UNC sharepoint and
+	// relative path.
+	//
+	// If the path contains a drive letter, drive will contain
+	// everything up to and including the colon. e.g.
+	// splitdrive("c:/dir") returns ("c:", "/dir")
+	//
+	// If the path contains a UNC path, drive will contain the host name
+	// and share, up to but not including the fourth separator. e.g.
+	// SplitDrive("//host/computer/dir") returns ("//host/computer", "/dir").
+	SplitDrive(path string) string
+
 	// SplitList mimics path/filepath.
 	SplitList(path string) []string
+
+	// SplitSuffix splits the pathname into a pair (root, suffix) such
+	// that root + suffix == path, and ext is empty or begins with a
+	// period and contains at most one period. Leading periods on the
+	// basename are ignored; SplitSuffix('.cshrc') returns ('.cshrc', '').
+	SplitSuffix(path string) (string, string)
 
 	// ToSlash mimics path/filepath.
 	ToSlash(path string) string

--- a/filepath/unix.go
+++ b/filepath/unix.go
@@ -79,3 +79,13 @@ func (UnixRenderer) ToSlash(path string) string {
 func (UnixRenderer) VolumeName(path string) string {
 	return ""
 }
+
+// NormCase implements Renderer.
+func (UnixRenderer) NormCase(path string) string {
+	return path
+}
+
+// SplitSuffix implements Renderer.
+func (UnixRenderer) SplitSuffix(path string) (string, string) {
+	return splitSuffix(path)
+}

--- a/filepath/unix_test.go
+++ b/filepath/unix_test.go
@@ -63,6 +63,45 @@ func (s unixSuite) TestVolumeName(c *gc.C) {
 	c.Check(volumeName, gc.Equals, "")
 }
 
+func (s unixSuite) TestNormCaseLower(c *gc.C) {
+	normalized := s.renderer.NormCase("spam")
+
+	c.Check(normalized, gc.Equals, "spam")
+}
+
+func (s unixSuite) TestNormCaseUpper(c *gc.C) {
+	normalized := s.renderer.NormCase("SPAM")
+
+	c.Check(normalized, gc.Equals, "SPAM")
+}
+
+func (s unixSuite) TestNormCaseMixed(c *gc.C) {
+	normalized := s.renderer.NormCase("sPaM")
+
+	c.Check(normalized, gc.Equals, "sPaM")
+}
+
+func (s unixSuite) TestNormCaseCapitalized(c *gc.C) {
+	normalized := s.renderer.NormCase("Spam")
+
+	c.Check(normalized, gc.Equals, "Spam")
+}
+
+func (s unixSuite) TestNormCasePunctuation(c *gc.C) {
+	normalized := s.renderer.NormCase("spam-eggs.ext")
+
+	c.Check(normalized, gc.Equals, "spam-eggs.ext")
+}
+
+func (s unixSuite) TestSplitSuffix(c *gc.C) {
+	// This is just a sanity check. The splitSuffix tests are more
+	// comprehensive.
+	path, suffix := s.renderer.SplitSuffix("spam.ext")
+
+	c.Check(path, gc.Equals, "spam")
+	c.Check(suffix, gc.Equals, ".ext")
+}
+
 // unixThinWrapperSuite contains test methods for UnixRenderer methods
 // that are just thin wrappers around the corresponding helpers in the
 // filepath package. As such the test coverage is minimal (more of a

--- a/filepath/win.go
+++ b/filepath/win.go
@@ -111,6 +111,16 @@ func (WindowsRenderer) VolumeName(path string) string {
 	return path[:volumeNameLen(path)]
 }
 
+// NormCase implements Renderer.
+func (WindowsRenderer) NormCase(path string) string {
+	return strings.ToLower(path)
+}
+
+// SplitSuffix implements Renderer.
+func (WindowsRenderer) SplitSuffix(path string) (string, string) {
+	return splitSuffix(path)
+}
+
 func isSlash(c uint8) bool {
 	return c == WindowsSeparator || c == '/'
 }

--- a/filepath/win_test.go
+++ b/filepath/win_test.go
@@ -67,6 +67,45 @@ func (s windowsSuite) TestVolumeName(c *gc.C) {
 	}
 }
 
+func (s windowsSuite) TestNormCaseLower(c *gc.C) {
+	normalized := s.renderer.NormCase("spam")
+
+	c.Check(normalized, gc.Equals, "spam")
+}
+
+func (s windowsSuite) TestNormCaseUpper(c *gc.C) {
+	normalized := s.renderer.NormCase("SPAM")
+
+	c.Check(normalized, gc.Equals, "spam")
+}
+
+func (s windowsSuite) TestNormCaseMixed(c *gc.C) {
+	normalized := s.renderer.NormCase("sPaM")
+
+	c.Check(normalized, gc.Equals, "spam")
+}
+
+func (s windowsSuite) TestNormCaseCapitalized(c *gc.C) {
+	normalized := s.renderer.NormCase("Spam")
+
+	c.Check(normalized, gc.Equals, "spam")
+}
+
+func (s windowsSuite) TestNormCasePunctuation(c *gc.C) {
+	normalized := s.renderer.NormCase("spam-eggs.ext")
+
+	c.Check(normalized, gc.Equals, "spam-eggs.ext")
+}
+
+func (s windowsSuite) TestSplitSuffix(c *gc.C) {
+	// This is just a sanity check. The splitSuffix tests are more
+	// comprehensive.
+	path, suffix := s.renderer.SplitSuffix("spam.ext")
+
+	c.Check(path, gc.Equals, "spam")
+	c.Check(suffix, gc.Equals, ".ext")
+}
+
 // windowsThinWrapperSuite contains test methods for WindowsRenderer methods
 // that are just thin wrappers around the corresponding helpers in the
 // filepath package. As such the test coverage is minimal (more of a


### PR DESCRIPTION
NormCase is useful when dealing with Windows.  SplitSuffix is useful when dealing with file extensions.  Having these methods on Renderer helps with our cross-platform compatibility.  Both methods are inspired by Python's os.path module.

(Review request: http://reviews.vapour.ws/r/1537/)