### PR TITLE
fix quoting

### DIFF
--- a/debugstatus/status.go
+++ b/debugstatus/status.go
@@ -15,7 +15,7 @@ import (
 func Check(checkers ...CheckerFunc) map[string]CheckResult {
 	var mu sync.Mutex
 	results := make(map[string]CheckResult, len(checkers))
-	
+
 	var wg sync.WaitGroup
 	for _, c := range checkers {
 		c := c

--- a/trivial.go
+++ b/trivial.go
@@ -63,10 +63,10 @@ func ShQuote(s string) string {
 // within s will be interpreted as such.
 func WinPSQuote(s string) string {
 	// See http://ss64.com/ps/syntax-esc.html#quotes.
-    // Double quotes inside single quotes are fine, double single quotes inside
-    // single quotes, not so much so. Having double quoted strings inside single
-    // quoted strings, ensure no expansion happens.
-    return `'` + strings.Replace(s, `'`, `"`, -1) + `'`
+	// Double quotes inside single quotes are fine, double single quotes inside
+	// single quotes, not so much so. Having double quoted strings inside single
+	// quoted strings, ensure no expansion happens.
+	return `'` + strings.Replace(s, `'`, `"`, -1) + `'`
 }
 
 // WinCmdQuote quotes s so that when read by cmd.exe, no metacharacters

--- a/trivial.go
+++ b/trivial.go
@@ -63,7 +63,10 @@ func ShQuote(s string) string {
 // within s will be interpreted as such.
 func WinPSQuote(s string) string {
 	// See http://ss64.com/ps/syntax-esc.html#quotes.
-	return `'` + strings.Replace(s, `'`, `''`, -1) + `'`
+    // Double quotes inside single quotes are fine, double single quotes inside
+    // single quotes, not so much so. Having double quoted strings inside single
+    // quoted strings, ensure no expansion happens.
+    return `'` + strings.Replace(s, `'`, `"`, -1) + `'`
 }
 
 // WinCmdQuote quotes s so that when read by cmd.exe, no metacharacters

--- a/trivial_test.go
+++ b/trivial_test.go
@@ -71,11 +71,11 @@ func (*utilsSuite) TestWinCmdQuote(c *gc.C) {
 func (*utilsSuite) TestWinPSQuote(c *gc.C) {
 	args := map[string]string{
 		"":                 "''",
-		"a":                "'a'",
+		"a":                `'a'`,
 		`"a"`:              `'"a"'`,
-		"'a":               "'''a'",
-		"a'":               "'a'''",
-		"'a'":              "'''a'''",
+		"'a":               `'"a'`,
+		"a'":               `'a"'`,
+		"'a'":              `'"a"'`,
 		"abc > xyz 2>&1 &": "'abc > xyz 2>&1 &'",
 	}
 	checkQuoting(c, utils.WinPSQuote, args)


### PR DESCRIPTION
This partially fixes windows support inside juju-core. Services defined with:

New-Service -BinaryPathName '''C:\juju\lib\juju\tools\machine-1\jujud.exe'' machine --data-dir ''C:\juju\lib\juju'' --machine-id 2 --debug'

will fail to start. Note the double single quotes inside the single quoted string.

New-Service -BinaryPathName '"C:\juju\lib\juju\tools\machine-1\jujud.exe" machine --data-dir "C:\juju\lib\juju" --machine-id 2 --debug' <-- this will work.

(Review request: http://reviews.vapour.ws/r/1608/)