### PR TITLE
Add ChownPath

### DIFF
--- a/file_unix.go
+++ b/file_unix.go
@@ -6,8 +6,10 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"os/user"
+	"strconv"
 	"strings"
 
 	"github.com/juju/errors"
@@ -34,4 +36,22 @@ func MakeFileURL(in string) string {
 		return "file://" + in
 	}
 	return in
+}
+
+// ChownPath sets the uid and gid of path to match that of the user
+// specified.
+func ChownPath(path, username string) error {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return fmt.Errorf("cannot lookup %q user id: %v", username, err)
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return fmt.Errorf("invalid user id %q: %v", u.Uid, err)
+	}
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return fmt.Errorf("invalid group id %q: %v", u.Gid, err)
+	}
+	return os.Chown(path, uid, gid)
 }

--- a/file_windows.go
+++ b/file_windows.go
@@ -128,3 +128,11 @@ func homeDir(user string) (string, error) {
 	}
 	return homeFromRegistry(u)
 }
+
+// ChownPath is not implemented for Windows.
+func ChownPath(path, username string) error {
+	// This only exists to allow building on Windows. User lookup and
+	// file ownership needs to be handled in a completely different
+	// way and hasn't yet been implemented.
+	return nil
+}


### PR DESCRIPTION
This func sets the owner and group of a file to match the given username. This is needed in a couple of places in Juju so it is being extracted to here. It has not been implemented for Windows.

(Review request: http://reviews.vapour.ws/r/1838/)