### PR TITLE
utils: make uuid parsing more lenient

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -16,21 +16,17 @@ import (
 type UUID [16]byte
 
 // regex for validating that the UUID matches RFC 4122.
-// This package specifically generates and accepts version 4 UUIDs
-// where the string representation has the digit 4 at the beginning of
-// the third grouping, and one of the hex digits 8 through b at the
-// beginning of the fourth grouping.
+// This package generates version 4 UUIDs but
+// accepts any UUID version.
 // http://www.ietf.org/rfc/rfc4122.txt
 var (
 	block1  = "[0-9a-f]{8}"
 	block2  = "[0-9a-f]{4}"
-	version = "4"
-	block3  = "[0-9a-f]{3}"
-	variant = "[8,9,a,b]"
-	block4  = "[0-9a-f]{3}"
+	block3  = "[0-9a-f]{4}"
+	block4  = "[0-9a-f]{4}"
 	block5  = "[0-9a-f]{12}"
 
-	UUIDSnippet = block1 + "-" + block2 + "-" + version + block3 + "-" + variant + block4 + "-" + block5
+	UUIDSnippet = block1 + "-" + block2 + "-" + block3 + "-" + block4 + "-" + block5
 	validUUID   = regexp.MustCompile("^" + UUIDSnippet + "$")
 )
 

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -42,7 +42,7 @@ func (*uuidSuite) TestIsValidUUIDFailsWhenNotValid(c *gc.C) {
 	}{
 		{
 			utils.UUID{}.String(),
-			false,
+			true,
 		},
 		{
 			"",


### PR DESCRIPTION
This brings the UUID checking into line with the checking
done by UUID in juju/schema. There's no particular reason
to disallow other RFC4122 UUIDs. Once parsed
we treat the bytes as an opaque block, so whether it's
actually a version 4 UUID is immaterial.


(Review request: http://reviews.vapour.ws/r/1856/)