### PR TITLE
Trim whitespace out of keyvalues.

### DIFF
--- a/keyvalues/keyvalues.go
+++ b/keyvalues/keyvalues.go
@@ -25,16 +25,17 @@ func Parse(src []string, allowEmptyValues bool) (map[string]string, error) {
 	results := map[string]string{}
 	for _, kv := range src {
 		parts := strings.SplitN(kv, "=", 2)
-		if len(parts) != 2 || len(parts[0]) == 0 {
+		if len(parts) != 2 {
 			return nil, fmt.Errorf(`expected "key=value", got %q`, kv)
 		}
-		if !allowEmptyValues && len(parts[1]) == 0 {
-			return nil, fmt.Errorf(`expected "key=value", got %q`, kv)
+		key, value := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+		if len(key) == 0 || (!allowEmptyValues && len(value) == 0) {
+			return nil, fmt.Errorf(`expected "key=value", got "%s=%s"`, key, value)
 		}
-		if _, exists := results[parts[0]]; exists {
-			return nil, DuplicateError(fmt.Sprintf("key %q specified more than once", parts[0]))
+		if _, exists := results[key]; exists {
+			return nil, DuplicateError(fmt.Sprintf("key %q specified more than once", key))
 		}
-		results[parts[0]] = parts[1]
+		results[key] = value
 	}
 	return results, nil
 }

--- a/keyvalues/keyvalues_test.go
+++ b/keyvalues/keyvalues_test.go
@@ -85,6 +85,36 @@ var testCases = []struct {
 	allowEmptyVal: true,
 	output:        map[string]string{"key": ""},
 	error:         "",
+}, {
+	about:         "whitespace trimmed",
+	input:         []string{"key=value\n", "key2\t=\tvalue2"},
+	allowEmptyVal: true,
+	output:        map[string]string{"key": "value", "key2": "value2"},
+	error:         "",
+}, {
+	about:         "whitespace trimming and duplicate keys",
+	input:         []string{"key =value", "key\t=\tvalue2"},
+	allowEmptyVal: true,
+	output:        nil,
+	error:         `key "key" specified more than once`,
+}, {
+	about:         "whitespace trimming and empty value not allowed",
+	input:         []string{"key=    "},
+	allowEmptyVal: false,
+	output:        nil,
+	error:         `expected "key=value", got "key="`,
+}, {
+	about:         "whitespace trimming and empty value",
+	input:         []string{"key=    "},
+	allowEmptyVal: true,
+	output:        map[string]string{"key": ""},
+	error:         "",
+}, {
+	about:         "whitespace trimming and missing key",
+	input:         []string{"   =value"},
+	allowEmptyVal: true,
+	output:        nil,
+	error:         `expected "key=value", got "=value"`,
 }}
 
 func (keyValuesSuite) TestMapParsing(c *gc.C) {


### PR DESCRIPTION
Ran into a problem with one of the hook tools that would benefit from trimmed whitespace. This should address a whole class of potential problems with whitespace creeping into os.Args.

(Review request: http://reviews.vapour.ws/r/2064/)