### PR TITLE
Add atomic MoveFile that does not overwrite.

### DIFF
--- a/file_test.go
+++ b/file_test.go
@@ -202,9 +202,6 @@ func (*fileSuite) TestMoveFile(c *gc.C) {
 	c.Assert(ok, gc.Equals, false)
 	c.Assert(err, gc.NotNil)
 
-	st, err := os.Stat(dest)
-	c.Assert(err, gc.IsNil)
-	c.Assert(st.Size(), gc.Equals, int64(8))
 	contents, err := ioutil.ReadFile(dest)
 	c.Assert(err, gc.IsNil)
 	c.Assert(contents, gc.DeepEquals, []byte("macaroni"))

--- a/file_test.go
+++ b/file_test.go
@@ -183,3 +183,29 @@ func (*fileSuite) TestAtomicWriteFile(c *gc.C) {
 		c.Assert(os.Remove(path), gc.IsNil)
 	}
 }
+
+func (*fileSuite) TestMoveFile(c *gc.C) {
+	d := c.MkDir()
+	dest := filepath.Join(d, "foo")
+	f1Name := filepath.Join(d, ".foo1")
+	f2Name := filepath.Join(d, ".foo2")
+	err := ioutil.WriteFile(f1Name, []byte("macaroni"), 0644)
+	c.Assert(err, gc.IsNil)
+	err = ioutil.WriteFile(f2Name, []byte("cheese"), 0644)
+	c.Assert(err, gc.IsNil)
+
+	ok, err := utils.MoveFile(f1Name, dest)
+	c.Assert(ok, gc.Equals, true)
+	c.Assert(err, gc.IsNil)
+
+	ok, err = utils.MoveFile(f2Name, dest)
+	c.Assert(ok, gc.Equals, false)
+	c.Assert(err, gc.NotNil)
+
+	st, err := os.Stat(dest)
+	c.Assert(err, gc.IsNil)
+	c.Assert(st.Size(), gc.Equals, int64(8))
+	contents, err := ioutil.ReadFile(dest)
+	c.Assert(err, gc.IsNil)
+	c.Assert(contents, gc.DeepEquals, []byte("macaroni"))
+}

--- a/file_unix.go
+++ b/file_unix.go
@@ -23,6 +23,24 @@ func homeDir(userName string) (string, error) {
 	return u.HomeDir, nil
 }
 
+// MoveFile atomically moves the source file to the destination, returning
+// whether the file was moved successfully. If the destination already exists,
+// it returns an error rather than overwrite it.
+//
+// On unix systems, an error may occur with a successful move, if the source
+// file location cannot be unlinked.
+func MoveFile(source, destination string) (bool, error) {
+	err := os.Link(source, destination)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	err = os.Remove(source)
+	if err != nil {
+		return true, errors.Trace(err)
+	}
+	return true, nil
+}
+
 // ReplaceFile atomically replaces the destination file or directory
 // with the source. The errors that are returned are identical to
 // those returned by os.Rename.

--- a/file_unix.go
+++ b/file_unix.go
@@ -32,11 +32,11 @@ func homeDir(userName string) (string, error) {
 func MoveFile(source, destination string) (bool, error) {
 	err := os.Link(source, destination)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, err
 	}
 	err = os.Remove(source)
 	if err != nil {
-		return true, errors.Trace(err)
+		return true, err
 	}
 	return true, nil
 }

--- a/file_windows.go
+++ b/file_windows.go
@@ -23,6 +23,27 @@ const (
 
 //sys moveFileEx(lpExistingFileName *uint16, lpNewFileName *uint16, dwFlags uint32) (err error) = MoveFileExW
 
+// MoveFile atomically moves the source file to the destination, returning
+// whether the file was moved successfully. If the destination already exists,
+// it returns an error rather than overwrite it.
+func MoveFile(source, destination string) (bool, error) {
+	src, err := syscall.UTF16PtrFromString(source)
+	if err != nil {
+		return false, &os.LinkError{"replace", source, destination, err}
+	}
+	dest, err := syscall.UTF16PtrFromString(destination)
+	if err != nil {
+		return false, &os.LinkError{"replace", source, destination, err}
+	}
+
+	// see http://msdn.microsoft.com/en-us/library/windows/desktop/aa365240(v=vs.85).aspx
+	if err := moveFileEx(src, dest, movefile_write_through); err != nil {
+		return false, &os.LinkError{"replace", source, destination, err}
+	}
+	return true, nil
+
+}
+
 // ReplaceFile atomically replaces the destination file or directory with the source.
 // The errors that are returned are identical to those returned by os.Rename.
 func ReplaceFile(source, destination string) error {

--- a/file_windows.go
+++ b/file_windows.go
@@ -29,16 +29,16 @@ const (
 func MoveFile(source, destination string) (bool, error) {
 	src, err := syscall.UTF16PtrFromString(source)
 	if err != nil {
-		return false, &os.LinkError{"replace", source, destination, err}
+		return false, &os.LinkError{"move", source, destination, err}
 	}
 	dest, err := syscall.UTF16PtrFromString(destination)
 	if err != nil {
-		return false, &os.LinkError{"replace", source, destination, err}
+		return false, &os.LinkError{"move", source, destination, err}
 	}
 
 	// see http://msdn.microsoft.com/en-us/library/windows/desktop/aa365240(v=vs.85).aspx
 	if err := moveFileEx(src, dest, movefile_write_through); err != nil {
-		return false, &os.LinkError{"replace", source, destination, err}
+		return false, &os.LinkError{"move", source, destination, err}
 	}
 	return true, nil
 


### PR DESCRIPTION
An atomic MoveFile that returns an error rather than overwrites the destination. This will be used to address [LP1475271](https://bugs.launchpad.net/juju-core/+bug/1475271).

(Review request: http://reviews.vapour.ws/r/2188/)