### PR TITLE
cache: new package

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,165 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// Package cache provides a simple caching mechanism
+// that limits the age of cache entries and tries to avoid large
+// repopulation events by staggering refresh times.
+package cache
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+
+	"gopkg.in/errgo.v1"
+)
+
+// entry holds a cache entry. The expire field
+// holds the time after which the entry will be
+// considered invalid.
+type entry struct {
+	value  interface{}
+	expire time.Time
+}
+
+// Key represents a cache key. It must be a comparable type.
+type Key interface{}
+
+// Cache holds a time-limited set of values for arbitrary keys.
+type Cache struct {
+	maxAge time.Duration
+
+	// mu guards the fields below it.
+	mu sync.Mutex
+
+	// expire holds when the cache is due to expire.
+	expire time.Time
+
+	// We hold two maps so that can avoid scanning through all the
+	// items in the cache when the cache needs to be refreshed.
+	// Instead, we move items from old to new when they're accessed
+	// and throw away the old map at refresh time.
+	old, new map[Key]entry
+}
+
+// New returns a new Cache that will cache items for
+// at most maxAge.
+func New(maxAge time.Duration) *Cache {
+	// A maxAge is < 2ns then the expiry code will panic because the
+	// actual expiry time will be maxAge - a random value in the
+	// interval [0, maxAge/2). If maxAge is < 2ns then this requires
+	// a random interval in [0, 0) which causes a panic.
+	if maxAge < 2*time.Nanosecond {
+		maxAge = 2 * time.Nanosecond
+	}
+	// The returned cache will have a zero-valued expire
+	// time, so will expire immediately, causing the new
+	// map to be created.
+	return &Cache{
+		maxAge: maxAge,
+	}
+}
+
+// Len returns the total number of cached entries.
+func (c *Cache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.old) + len(c.new)
+}
+
+// Evict removes the entry with the given key from the cache if present.
+func (c *Cache) Evict(key Key) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.new, key)
+	delete(c.old, key)
+}
+
+// EvictAll removes all entries from the cache.
+func (c *Cache) EvictAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.new = make(map[Key]entry)
+	c.old = nil
+}
+
+// Get returns the value for the given key, using fetch to fetch
+// the value if it is not found in the cache.
+// If fetch returns an error, the returned error from Get will have
+// the same cause.
+func (c *Cache) Get(key Key, fetch func() (interface{}, error)) (interface{}, error) {
+	return c.getAtTime(key, fetch, time.Now())
+}
+
+// getAtTime is the internal version of Get, useful for testing; now represents the current
+// time.
+func (c *Cache) getAtTime(key Key, fetch func() (interface{}, error), now time.Time) (interface{}, error) {
+	if val, ok := c.cachedValue(key, now); ok {
+		return val, nil
+	}
+	// Fetch the data without the mutex held
+	// so that one slow fetch doesn't hold up
+	// all the other cache accesses.
+	val, err := fetch()
+	if err != nil {
+		// TODO consider caching cache misses.
+		return nil, errgo.Mask(err, errgo.Any)
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Add the new cache entry. Because it's quite likely that a
+	// large number of cache entries will be initially fetched at
+	// the same time, we want to avoid a thundering herd of fetches
+	// when they all expire at the same time, so we set the expiry
+	// time to a random interval between [now + t.maxAge/2, now +
+	// t.maxAge] and so they'll be spread over time without
+	// compromising the maxAge value.
+	c.new[key] = entry{
+		value:  val,
+		expire: now.Add(c.maxAge - time.Duration(rand.Int63n(int64(c.maxAge/2)))),
+	}
+	return val, nil
+}
+
+// cachedValue returns any cached value for the given key
+// and whether it was found.
+func (c *Cache) cachedValue(key Key, now time.Time) (interface{}, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if now.After(c.expire) {
+		c.old = c.new
+		c.new = make(map[Key]entry)
+		c.expire = now.Add(c.maxAge)
+	}
+	if e, ok := c.entry(c.new, key, now); ok {
+		return e.value, true
+	}
+	if e, ok := c.entry(c.old, key, now); ok {
+		// An old entry has been accessed; move it to the new
+		// map so that we only use a single map access for
+		// subsequent lookups. Note that because we use the same
+		// duration for cache refresh (c.expire) as for max
+		// entry age, this is strictly speaking unnecessary
+		// because any entries in old will have expired by the
+		// time it is dropped.
+		c.new[key] = e
+		delete(c.old, key)
+		return e.value, true
+	}
+	return nil, false
+}
+
+// entry returns an entry from the map and whether it
+// was found. If the entry has expired, it is deleted from the map.
+func (c *Cache) entry(m map[Key]entry, key Key, now time.Time) (entry, bool) {
+	e, ok := m[key]
+	if !ok {
+		return entry{}, false
+	}
+	if now.After(e.expire) {
+		// Delete expired entries.
+		delete(m, key)
+		return entry{}, false
+	}
+	return e, true
+}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,256 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package cache_test
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
+
+	"github.com/juju/utils/cache"
+)
+
+type suite struct{}
+
+var _ = gc.Suite(&suite{})
+
+func (*suite) TestSimpleGet(c *gc.C) {
+	p := cache.New(time.Hour)
+	v, err := p.Get("a", fetchValue(2))
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, 2)
+}
+
+func (*suite) TestEvict(c *gc.C) {
+	p := cache.New(time.Hour)
+	v, err := p.Get("a", fetchValue(2))
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, 2)
+
+	v, err = p.Get("a", fetchValue(4))
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, 2)
+
+	p.Evict("a")
+	v, err = p.Get("a", fetchValue(3))
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, 3)
+
+	v, err = p.Get("a", fetchValue(4))
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, 3)
+}
+
+func (*suite) TestEvictOld(c *gc.C) {
+	// Test that evict removes entries even when they're
+	// in the old map.
+
+	now := time.Now()
+	p := cache.New(time.Minute)
+
+	// Populate the cache with an initial entry.
+	v, err := cache.GetAtTime(p, "a", fetchValue("a"), now)
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, "a")
+	c.Assert(p.Len(), gc.Equals, 1)
+
+	v, err = cache.GetAtTime(p, "b", fetchValue("b"), now.Add(time.Minute/2))
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, "b")
+	c.Assert(p.Len(), gc.Equals, 2)
+
+	// Fetch an item after the expiry time,
+	// causing current entries to be moved to old.
+	v, err = cache.GetAtTime(p, "a", fetchValue("a1"), now.Add(time.Minute+1))
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, "a1")
+	c.Assert(p.Len(), gc.Equals, 2)
+	c.Assert(cache.OldLen(p), gc.Equals, 1)
+
+	p.Evict("b")
+	v, err = cache.GetAtTime(p, "b", fetchValue("b1"), now.Add(time.Minute+2))
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, "b1")
+}
+
+func (*suite) TestFetchError(c *gc.C) {
+	p := cache.New(time.Hour)
+	expectErr := errgo.New("hello")
+	v, err := p.Get("a", fetchError(expectErr))
+	c.Assert(err, gc.ErrorMatches, "hello")
+	c.Assert(errgo.Cause(err), gc.Equals, expectErr)
+	c.Assert(v, gc.Equals, nil)
+}
+
+func (*suite) TestFetchOnlyOnce(c *gc.C) {
+	p := cache.New(time.Hour)
+	v, err := p.Get("a", fetchValue(2))
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, 2)
+
+	v, err = p.Get("a", fetchError(errUnexpectedFetch))
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, 2)
+}
+
+func (*suite) TestEntryExpiresAfterMaxEntryAge(c *gc.C) {
+	now := time.Now()
+	p := cache.New(time.Minute)
+	v, err := cache.GetAtTime(p, "a", fetchValue(2), now)
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, 2)
+
+	// Entry is definitely not expired before half the entry expiry time.
+	v, err = cache.GetAtTime(p, "a", fetchError(errUnexpectedFetch), now.Add(time.Minute/2-1))
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, 2)
+
+	// Entry is definitely expired after the entry expiry time
+	v, err = cache.GetAtTime(p, "a", fetchValue(3), now.Add(time.Minute+1))
+	c.Assert(v, gc.Equals, 3)
+}
+
+func (*suite) TestEntriesRemovedWhenNotRetrieved(c *gc.C) {
+	now := time.Now()
+	p := cache.New(time.Minute)
+
+	// Populate the cache with an initial entry.
+	v, err := cache.GetAtTime(p, "a", fetchValue("a"), now)
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, "a")
+	c.Assert(p.Len(), gc.Equals, 1)
+
+	// Fetch another item after the expiry time,
+	// causing current entries to be moved to old.
+	v, err = cache.GetAtTime(p, "b", fetchValue("b"), now.Add(time.Minute+1))
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, "b")
+	c.Assert(p.Len(), gc.Equals, 2)
+	c.Assert(cache.OldLen(p), gc.Equals, 1)
+
+	// Fetch the other item after another expiry time
+	// causing the old entries to be discarded because
+	// nothing has fetched them.
+	v, err = cache.GetAtTime(p, "b", fetchValue("b"), now.Add(time.Minute*2+2))
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, "b")
+	c.Assert(p.Len(), gc.Equals, 1)
+}
+
+// TestRefreshedEntry tests the code path where a value is moved
+// from the old map to new.
+func (*suite) TestRefreshedEntry(c *gc.C) {
+	now := time.Now()
+	p := cache.New(time.Minute)
+
+	// Populate the cache with an initial entry.
+	v, err := cache.GetAtTime(p, "a", fetchValue("a"), now)
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, "a")
+	c.Assert(p.Len(), gc.Equals, 1)
+
+	// Fetch another item very close to the expiry time.
+	v, err = cache.GetAtTime(p, "b", fetchValue("b"), now.Add(time.Minute-1))
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, "b")
+	c.Assert(p.Len(), gc.Equals, 2)
+
+	// Fetch it again just after the expiry time,
+	// which should move it into the new map.
+	v, err = cache.GetAtTime(p, "b", fetchError(errUnexpectedFetch), now.Add(time.Minute+1))
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, "b")
+	c.Assert(p.Len(), gc.Equals, 2)
+
+	// Fetch another item, causing "a" to be removed from the cache
+	// and keeping "b" in there.
+	v, err = cache.GetAtTime(p, "c", fetchValue("c"), now.Add(time.Minute*2+2))
+	c.Assert(err, gc.IsNil)
+	c.Assert(v, gc.Equals, "c")
+	c.Assert(p.Len(), gc.Equals, 2)
+}
+
+// TestConcurrentFetch checks that the cache is safe
+// to use concurrently. It is designed to fail when
+// tested with the race detector enabled.
+func (*suite) TestConcurrentFetch(c *gc.C) {
+	p := cache.New(time.Minute)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		v, err := p.Get("a", fetchValue("a"))
+		c.Check(err, gc.IsNil)
+		c.Check(v, gc.Equals, "a")
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		v, err := p.Get("b", fetchValue("b"))
+		c.Check(err, gc.IsNil)
+		c.Check(v, gc.Equals, "b")
+	}()
+	wg.Wait()
+}
+
+func (*suite) TestRefreshSpread(c *gc.C) {
+	now := time.Now()
+	p := cache.New(time.Minute)
+	// Get all values to start with.
+	const N = 100
+	for i := 0; i < N; i++ {
+		v, err := cache.GetAtTime(p, fmt.Sprint(i), fetchValue(i), now)
+		c.Assert(err, gc.IsNil)
+		c.Assert(v, gc.Equals, i)
+	}
+	counts := make([]int, time.Minute/time.Millisecond/10+1)
+
+	// Continually get values over the course of the
+	// expiry time; the fetches should be spread out.
+	slot := 0
+	for t := now.Add(0); t.Before(now.Add(time.Minute + 1)); t = t.Add(time.Millisecond * 10) {
+		for i := 0; i < N; i++ {
+			cache.GetAtTime(p, fmt.Sprint(i), func() (interface{}, error) {
+				counts[slot]++
+				return i, nil
+			}, t)
+		}
+		slot++
+	}
+
+	// There should be no fetches in the first half of the cycle.
+	for i := 0; i < len(counts)/2; i++ {
+		c.Assert(counts[i], gc.Equals, 0, gc.Commentf("slot %d", i))
+	}
+
+	max := 0
+	total := 0
+	for _, count := range counts {
+		if count > max {
+			max = count
+		}
+		total += count
+	}
+	if max > 10 {
+		c.Errorf("requests grouped too closely (max %d)", max)
+	}
+	c.Assert(total, gc.Equals, N)
+}
+
+var errUnexpectedFetch = errgo.New("fetch called unexpectedly")
+
+func fetchError(err error) func() (interface{}, error) {
+	return func() (interface{}, error) {
+		return nil, err
+	}
+}
+
+func fetchValue(val interface{}) func() (interface{}, error) {
+	return func() (interface{}, error) {
+		return val, nil
+	}
+}

--- a/cache/export_test.go
+++ b/cache/export_test.go
@@ -1,0 +1,10 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package cache
+
+var GetAtTime = (*Cache).getAtTime
+
+func OldLen(c *Cache) int {
+	return len(c.old)
+}

--- a/cache/package_test.go
+++ b/cache/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package cache_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
This provides a simple caching mechanism. We're moving this
from the charmstore package internal packages so that
it can be used elsewhere too.

One change from the original: we allow arbitrary keys
rather than restricting to just strings.

(Review request: http://reviews.vapour.ws/r/2198/)