### PR TITLE
Changed %q to %s on addRepository

### DIFF
--- a/packaging/commands/apt.go
+++ b/packaging/commands/apt.go
@@ -47,7 +47,7 @@ var aptCmder = packageCommander{
 	isInstalled:         buildCommand(dpkgquery, "-s %s"),
 	listAvailable:       buildCommand(aptcache, "pkgnames"),
 	listInstalled:       buildCommand(dpkg, "--get-selections"),
-	addRepository:       buildCommand(addaptrepo, "%q"),
+	addRepository:       buildCommand(addaptrepo, "%s"),
 	listRepositories:    buildCommand(`sed -r -n "s|^deb(-src)? (.*)|\2|p"`, "/etc/apt/sources.list"),
 	removeRepository:    buildCommand(addaptrepo, "--remove ppa:%s"),
 	cleanup:             buildCommand(aptget, "autoremove"),


### PR DESCRIPTION
The add repository commands were generated with 2 sets of quotes. 
For example: add-apt-repository ""<repo-name>"". 

This patch fixes this.