### PR TITLE
utils/clock: add clock package

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -1,0 +1,25 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package clock
+
+import "time"
+
+// Clock provides an interface for dealing with clocks.
+type Clock interface {
+
+	// Now returns the current clock time.
+	Now() time.Time
+
+	// After waits for the duration to elapse and then sends the
+	// current time on the returned channel.
+	After(time.Duration) <-chan time.Time
+}
+
+// Alarm returns a channel that will have the time sent on it at some point
+// after the supplied time occurs.
+//
+// This is short for c.After(t.Sub(c.Now())).
+func Alarm(c Clock, t time.Time) <-chan time.Time {
+	return c.After(t.Sub(c.Now()))
+}

--- a/clock/wall.go
+++ b/clock/wall.go
@@ -1,0 +1,25 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package clock
+
+import (
+	"time"
+)
+
+// WallClock exposes wall-clock time via the Clock interface.
+var WallClock wallClock
+
+// WallClock exposes wall-clock time as returned by time.Now.
+type wallClock struct{}
+
+// Now is part of the Clock interface.
+func (wallClock) Now() time.Time {
+	return time.Now()
+}
+
+// Alarm returns a channel that will send a value at some point after
+// the supplied time.
+func (wallClock) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}


### PR DESCRIPTION
Add a clock package which contains a Clock
interface, and WallClock var whose type
implements Clock in terms of the wall clock.

(Review request: http://reviews.vapour.ws/r/2327/)