### PR TITLE
return new HTTP clients rather than aliasing http.DefaultClient

### DIFF
--- a/http.go
+++ b/http.go
@@ -57,22 +57,17 @@ func GetHTTPClient(verify SSLHostnameVerification) *http.Client {
 // GetValidatingHTTPClient returns a new http.Client that
 // verifies the server's certificate chain and hostname.
 func GetValidatingHTTPClient() *http.Client {
-	logger.Tracef("hostname SSL verification enabled")
-	return http.DefaultClient
+	return &http.Client{}
 }
 
 // GetNonValidatingHTTPClient returns a new http.Client that
 // does not verify the server's certificate chain and hostname.
 func GetNonValidatingHTTPClient() *http.Client {
-	logger.Tracef("hostname SSL verification disabled")
-	insecureClientMutex.Lock()
-	defer insecureClientMutex.Unlock()
-	if insecureClient == nil {
-		insecureConfig := &tls.Config{InsecureSkipVerify: true}
-		insecureTransport := NewHttpTLSTransport(insecureConfig)
-		insecureClient = &http.Client{Transport: insecureTransport}
+	return &http.Client{
+		Transport: NewHttpTLSTransport(&tls.Config{
+			InsecureSkipVerify: true,
+		}),
 	}
-	return insecureClient
 }
 
 // NewHttpTLSTransport returns a new http.Transport constructed with the TLS config

--- a/uuid.go
+++ b/uuid.go
@@ -20,11 +20,11 @@ type UUID [16]byte
 // accepts any UUID version.
 // http://www.ietf.org/rfc/rfc4122.txt
 var (
-	block1  = "[0-9a-f]{8}"
-	block2  = "[0-9a-f]{4}"
-	block3  = "[0-9a-f]{4}"
-	block4  = "[0-9a-f]{4}"
-	block5  = "[0-9a-f]{12}"
+	block1 = "[0-9a-f]{8}"
+	block2 = "[0-9a-f]{4}"
+	block3 = "[0-9a-f]{4}"
+	block4 = "[0-9a-f]{4}"
+	block5 = "[0-9a-f]{12}"
 
 	UUIDSnippet = block1 + "-" + block2 + "-" + block3 + "-" + block4 + "-" + block5
 	validUUID   = regexp.MustCompile("^" + UUIDSnippet + "$")


### PR DESCRIPTION
This makes the Get*HTTPClient functions return a new client
each time they are called, implementing the semantics described in the
doc comments.

This fixes bugs where callers were setting fields in the returned
clients and unintentionally setting http.DefaultClient attributes
as a result and hence breaking test isolation.


(Review request: http://reviews.vapour.ws/r/2569/)