### PR TITLE
bzr: new package

### DIFF
--- a/bzr/bzr.go
+++ b/bzr/bzr.go
@@ -1,0 +1,162 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package bzr offers an interface to manage branches of the Bazaar VCS.
+package bzr
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+)
+
+// Branch represents a Bazaar branch.
+type Branch struct {
+	location string
+	env      []string
+}
+
+// New returns a new Branch for the Bazaar branch at location.
+func New(location string) *Branch {
+	b := &Branch{location, cenv()}
+	if _, err := os.Stat(location); err == nil {
+		stdout, _, err := b.bzr("root")
+		if err == nil {
+			// Need to trim \r as well as \n for Windows compatibility
+			b.location = strings.TrimRight(string(stdout), "\r\n")
+		}
+	}
+	return b
+}
+
+// cenv returns a copy of the current process environment with LC_ALL=C.
+func cenv() []string {
+	env := os.Environ()
+	for i, pair := range env {
+		if strings.HasPrefix(pair, "LC_ALL=") {
+			env[i] = "LC_ALL=C"
+			return env
+		}
+	}
+	return append(env, "LC_ALL=C")
+}
+
+// Location returns the location of branch b.
+func (b *Branch) Location() string {
+	return b.location
+}
+
+// Join returns b's location with parts appended as path components.
+// In other words, if b's location is "lp:foo", and parts is {"bar, baz"},
+// Join returns "lp:foo/bar/baz".
+func (b *Branch) Join(parts ...string) string {
+	return path.Join(append([]string{b.location}, parts...)...)
+}
+
+func (b *Branch) bzr(subcommand string, args ...string) (stdout, stderr []byte, err error) {
+	cmd := exec.Command("bzr", append([]string{subcommand}, args...)...)
+	if _, err := os.Stat(b.location); err == nil {
+		cmd.Dir = b.location
+	}
+	errbuf := &bytes.Buffer{}
+	cmd.Stderr = errbuf
+	cmd.Env = b.env
+	stdout, err = cmd.Output()
+	// Some commands fail with exit status 0 (e.g. bzr root). :-(
+	if err != nil || bytes.Contains(errbuf.Bytes(), []byte("ERROR")) {
+		var errmsg string
+		if err != nil {
+			errmsg = err.Error()
+		}
+		return nil, nil, fmt.Errorf(`error running "bzr %s": %s%s%s`, subcommand, stdout, errbuf.Bytes(), errmsg)
+	}
+	return stdout, errbuf.Bytes(), err
+}
+
+// Init intializes a new branch at b's location.
+func (b *Branch) Init() error {
+	_, _, err := b.bzr("init", b.location)
+	return err
+}
+
+// Add adds to b the path resultant from calling b.Join(parts...).
+func (b *Branch) Add(parts ...string) error {
+	_, _, err := b.bzr("add", b.Join(parts...))
+	return err
+}
+
+// Commit commits pending changes into b.
+func (b *Branch) Commit(message string) error {
+	_, _, err := b.bzr("commit", "-q", "-m", message)
+	return err
+}
+
+// RevisionId returns the Bazaar revision id for the tip of b.
+func (b *Branch) RevisionId() (string, error) {
+	stdout, stderr, err := b.bzr("revision-info", "-d", b.location)
+	if err != nil {
+		return "", err
+	}
+	pair := bytes.Fields(stdout)
+	if len(pair) != 2 {
+		return "", fmt.Errorf(`invalid output from "bzr revision-info": %s%s`, stdout, stderr)
+	}
+	id := string(pair[1])
+	if id == "null:" {
+		return "", fmt.Errorf("branch has no content")
+	}
+	return id, nil
+}
+
+// PushLocation returns the default push location for b.
+func (b *Branch) PushLocation() (string, error) {
+	stdout, _, err := b.bzr("info", b.location)
+	if err != nil {
+		return "", err
+	}
+	if i := bytes.Index(stdout, []byte("push branch:")); i >= 0 {
+		return string(stdout[i+13 : i+bytes.IndexAny(stdout[i:], "\r\n")]), nil
+	}
+	return "", fmt.Errorf("no push branch location defined")
+}
+
+// PushAttr holds options for the Branch.Push method.
+type PushAttr struct {
+	Location string // Location to push to. Use the default push location if empty.
+	Remember bool   // Whether to remember the location being pushed to as the default.
+}
+
+// Push pushes any new revisions in b to attr.Location if that's
+// provided, or to the default push location otherwise.
+// See PushAttr for other options.
+func (b *Branch) Push(attr *PushAttr) error {
+	var args []string
+	if attr != nil {
+		if attr.Remember {
+			args = append(args, "--remember")
+		}
+		if attr.Location != "" {
+			args = append(args, attr.Location)
+		}
+	}
+	_, _, err := b.bzr("push", args...)
+	return err
+}
+
+// CheckClean returns an error if 'bzr status' is not clean.
+func (b *Branch) CheckClean() error {
+	stdout, _, err := b.bzr("status", b.location)
+	if err != nil {
+		return err
+	}
+	if bytes.Count(stdout, []byte{'\n'}) == 1 && bytes.Contains(stdout, []byte(`See "bzr shelve --list" for details.`)) {
+		return nil // Shelves are fine.
+	}
+	if len(stdout) > 0 {
+		return fmt.Errorf("branch is not clean (bzr status)")
+	}
+	return nil
+}

--- a/bzr/bzr_test.go
+++ b/bzr/bzr_test.go
@@ -1,0 +1,162 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bzr_test
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	stdtesting "testing"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils/bzr"
+)
+
+func Test(t *stdtesting.T) {
+	gc.TestingT(t)
+}
+
+var _ = gc.Suite(&BzrSuite{})
+
+type BzrSuite struct {
+	testing.CleanupSuite
+	b *bzr.Branch
+}
+
+const bzr_config = `[DEFAULT]
+email = testing <test@example.com>
+`
+
+func (s *BzrSuite) SetUpTest(c *gc.C) {
+	s.CleanupSuite.SetUpTest(c)
+	bzrdir := c.MkDir()
+	s.PatchEnvironment("BZR_HOME", bzrdir)
+	err := os.MkdirAll(filepath.Join(bzrdir, bzrHome), 0755)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(
+		filepath.Join(bzrdir, bzrHome, "bazaar.conf"),
+		[]byte(bzr_config), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	s.b = bzr.New(c.MkDir())
+	c.Assert(s.b.Init(), gc.IsNil)
+}
+
+func (s *BzrSuite) TestNewFindsRoot(c *gc.C) {
+	err := os.Mkdir(s.b.Join("dir"), 0755)
+	c.Assert(err, jc.ErrorIsNil)
+	b := bzr.New(s.b.Join("dir"))
+	// When bzr has to search for the root, it will expand any symlinks it
+	// found along the way.
+	path, err := filepath.EvalSymlinks(s.b.Location())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(b.Location(), jc.SamePath, path)
+}
+
+func (s *BzrSuite) TestJoin(c *gc.C) {
+	path := bzr.New("lp:foo").Join("baz", "bar")
+	c.Assert(path, gc.Equals, "lp:foo/baz/bar")
+}
+
+func (s *BzrSuite) TestErrorHandling(c *gc.C) {
+	err := bzr.New("/non/existent/path").Init()
+	c.Assert(err, gc.ErrorMatches, `(?s)error running "bzr init":.*does not exist.*`)
+}
+
+func (s *BzrSuite) TestInit(c *gc.C) {
+	_, err := os.Stat(s.b.Join(".bzr"))
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *BzrSuite) TestRevisionIdOnEmpty(c *gc.C) {
+	revid, err := s.b.RevisionId()
+	c.Assert(err, gc.ErrorMatches, "branch has no content")
+	c.Assert(revid, gc.Equals, "")
+}
+
+func (s *BzrSuite) TestCommit(c *gc.C) {
+	f, err := os.Create(s.b.Join("myfile"))
+	c.Assert(err, jc.ErrorIsNil)
+	f.Close()
+	err = s.b.Add("myfile")
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.b.Commit("my log message")
+	c.Assert(err, jc.ErrorIsNil)
+
+	revid, err := s.b.RevisionId()
+	c.Assert(err, jc.ErrorIsNil)
+
+	cmd := exec.Command("bzr", "log", "--long", "--show-ids", "-v", s.b.Location())
+	output, err := cmd.CombinedOutput()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(output), gc.Matches, "(?s).*revision-id: "+revid+"\n.*message:\n.*my log message\n.*added:\n.*myfile .*")
+}
+
+func (s *BzrSuite) TestPush(c *gc.C) {
+	b1 := bzr.New(c.MkDir())
+	b2 := bzr.New(c.MkDir())
+	b3 := bzr.New(c.MkDir())
+	c.Assert(b1.Init(), gc.IsNil)
+	c.Assert(b2.Init(), gc.IsNil)
+	c.Assert(b3.Init(), gc.IsNil)
+
+	// Create and add b1/file to the branch.
+	f, err := os.Create(b1.Join("file"))
+	c.Assert(err, jc.ErrorIsNil)
+	f.Close()
+	err = b1.Add("file")
+	c.Assert(err, jc.ErrorIsNil)
+	err = b1.Commit("added file")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Push file to b2.
+	err = b1.Push(&bzr.PushAttr{Location: b2.Location()})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Push location should be set to b2.
+	location, err := b1.PushLocation()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(location, jc.SamePath, b2.Location())
+
+	// Now push it to b3.
+	err = b1.Push(&bzr.PushAttr{Location: b3.Location()})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Push location is still set to b2.
+	location, err = b1.PushLocation()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(location, jc.SamePath, b2.Location())
+
+	// Push it again, this time with the remember flag set.
+	err = b1.Push(&bzr.PushAttr{Location: b3.Location(), Remember: true})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Now the push location has shifted to b3.
+	location, err = b1.PushLocation()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(location, jc.SamePath, b3.Location())
+
+	// Both b2 and b3 should have the file.
+	_, err = os.Stat(b2.Join("file"))
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = os.Stat(b3.Join("file"))
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *BzrSuite) TestCheckClean(c *gc.C) {
+	err := s.b.CheckClean()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Create and add b1/file to the branch.
+	f, err := os.Create(s.b.Join("file"))
+	c.Assert(err, jc.ErrorIsNil)
+	f.Close()
+
+	err = s.b.CheckClean()
+	c.Assert(err, gc.ErrorMatches, `branch is not clean \(bzr status\)`)
+}

--- a/bzr/bzr_unix_test.go
+++ b/bzr/bzr_unix_test.go
@@ -1,0 +1,9 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build !windows
+
+package bzr_test
+
+const bzrHome = ".bazaar"

--- a/bzr/bzr_windows_test.go
+++ b/bzr/bzr_windows_test.go
@@ -1,0 +1,9 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build windows
+
+package bzr_test
+
+const bzrHome = "Bazaar/2.0"


### PR DESCRIPTION
Move bzr utils package from juju/bzr to the utils repo.

A followup PR will remove the package from juju and adjust dependencies.tsv

(Review request: http://reviews.vapour.ws/r/2622/)