### PR TITLE
Removed breaking quote from formatting.

### DIFF
--- a/packaging/commands/apt.go
+++ b/packaging/commands/apt.go
@@ -47,7 +47,7 @@ var aptCmder = packageCommander{
 	isInstalled:         buildCommand(dpkgquery, "-s %s"),
 	listAvailable:       buildCommand(aptcache, "pkgnames"),
 	listInstalled:       buildCommand(dpkg, "--get-selections"),
-	addRepository:       buildCommand(addaptrepo, "%q"),
+	addRepository:       buildCommand(addaptrepo, "%s"),
 	listRepositories:    buildCommand(`sed -r -n "s|^deb(-src)? (.*)|\2|p"`, "/etc/apt/sources.list"),
 	removeRepository:    buildCommand(addaptrepo, "--remove ppa:%s"),
 	cleanup:             buildCommand(aptget, "autoremove"),

--- a/packaging/manager/manager_test.go
+++ b/packaging/manager/manager_test.go
@@ -193,6 +193,16 @@ var simpleTestCases = []*simpleTestCase{
 		},
 	},
 	&simpleTestCase{
+		"Test repository addition.",
+		"add-apt-repository --yes some-repo",
+		nil,
+		"yum-config-manager --add-repo some-repo",
+		nil,
+		func(pacman manager.PackageManager) (interface{}, error) {
+			return nil, pacman.AddRepository(testedRepoName)
+		},
+	},
+	&simpleTestCase{
 		"Test repository removal.",
 		aptCmder.RemoveRepositoryCmd(testedRepoName),
 		nil,


### PR DESCRIPTION
This extra quote was making apt-add-repository fail as the quotes where quoted and the repo was corrupted.

(Review request: http://reviews.vapour.ws/r/2784/)