### PR TITLE
lp1501381 - don't panic with empty version string

### DIFF
--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -164,7 +164,7 @@ var (
 // SeriesVersion returns the version for the specified series.
 func SeriesVersion(series string) (string, error) {
 	if series == "" {
-		panic("cannot pass empty series to SeriesVersion()")
+		return "", errors.Trace(unknownSeriesVersionError(""))
 	}
 	seriesVersionsMutex.Lock()
 	defer seriesVersionsMutex.Unlock()
@@ -182,7 +182,7 @@ func SeriesVersion(series string) (string, error) {
 // VersionSeries returns the series (e.g.trusty) for the specified version (e.g. 14.04).
 func VersionSeries(version string) (string, error) {
 	if version == "" {
-		panic("cannot pass empty version to VersionSeries()")
+		return "", errors.Trace(unknownVersionSeriesError(""))
 	}
 	seriesVersionsMutex.Lock()
 	defer seriesVersionsMutex.Unlock()

--- a/series/supportedseries_test.go
+++ b/series/supportedseries_test.go
@@ -99,12 +99,18 @@ func (s *supportedSeriesSuite) TestVersionSeriesValid(c *gc.C) {
 
 func (s *supportedSeriesSuite) TestVersionSeriesEmpty(c *gc.C) {
 	setSeriesTestData()
-	panicFunc := func() { series.VersionSeries("") }
-	c.Assert(panicFunc, gc.PanicMatches, ".*cannot pass empty version to VersionSeries.*")
+	_, err := series.VersionSeries("")
+	c.Assert(err, gc.ErrorMatches, `.*unknown series for version: "".*`)
 }
 
 func (s *supportedSeriesSuite) TestVersionSeriesInvalid(c *gc.C) {
 	setSeriesTestData()
 	_, err := series.VersionSeries("73655")
 	c.Assert(err, gc.ErrorMatches, `.*unknown series for version: "73655".*`)
+}
+
+func (s *supportedSeriesSuite) TestSeriesVersionEmpty(c *gc.C) {
+	setSeriesTestData()
+	_, err := series.SeriesVersion("")
+	c.Assert(err, gc.ErrorMatches, `.*unknown version for series: "".*`)
 }


### PR DESCRIPTION
Modified VersionSeries and SeriesVersion to just return
unknownSeries / Version error when passed an empty string.

(Review request: http://reviews.vapour.ws/r/2797/)