### PR TITLE
Added stale lock detection and removal logic.

### DIFF
--- a/fslock/fslock_test.go
+++ b/fslock/fslock_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
 	"launchpad.net/tomb"
 
 	"github.com/juju/utils/fslock"
@@ -346,4 +347,51 @@ func (s *fslockSuite) TestTomb(c *gc.C) {
 	c.Assert(err, gc.Equals, tomb.ErrDying)
 	c.Assert(lock.Message(), gc.Equals, "very busy")
 
+}
+
+func changeNoncePID(c *gc.C, lockFile string, PID int) {
+	var nonce fslock.Nonce
+	heldNonce, err := ioutil.ReadFile(lockFile)
+	c.Assert(err, gc.IsNil)
+	err = bson.Unmarshal(heldNonce, &nonce)
+	c.Assert(err, gc.IsNil)
+	nonce.PID = PID
+	nonceBytes, err := bson.Marshal(nonce)
+	c.Assert(err, gc.IsNil)
+	err = ioutil.WriteFile(lockFile, nonceBytes, 0755)
+	c.Assert(err, gc.IsNil)
+}
+
+func assertCanLock(c *gc.C, lock *fslock.Lock) {
+	err := lock.Lock("")
+	c.Assert(err, gc.IsNil)
+	c.Assert(lock.IsLocked(), gc.Equals, true)
+}
+
+func (s *fslockSuite) TestClean(c *gc.C) {
+	dir := c.MkDir()
+	lock, err := fslock.NewLock(dir, "testing")
+	c.Assert(err, gc.IsNil)
+	assertCanLock(c, lock)
+
+	// Make the lock stale by making it an hour older
+	lockFile := path.Join(dir, "testing", "held")
+	lockInfo, err := os.Lstat(lockFile)
+	c.Assert(err, gc.IsNil)
+	os.Chtimes(lockFile, lockInfo.ModTime().Add(-time.Hour), lockInfo.ModTime().Add(-time.Hour))
+	assertCanLock(c, lock)
+
+	// Change the PID to a process that doesn't exist.
+	changeNoncePID(c, lockFile, 0)
+	assertCanLock(c, lock)
+
+	// Change the PID to a process we can't look at the details of.
+	changeNoncePID(c, lockFile, 1)
+	assertCanLock(c, lock)
+
+	// Change the PID to an existing, non-Juju process. Should lock.
+	sleep, err := os.StartProcess("/bin/sleep", []string{"3"}, &os.ProcAttr{})
+	c.Assert(err, gc.IsNil)
+	changeNoncePID(c, lockFile, sleep.Pid)
+	assertCanLock(c, lock)
 }


### PR DESCRIPTION
This fixes a bug where if Juju was restarted with a lock file in place (for example, the machine was rebooted) then the lock would remain but nothing held it. This logic will delete an existing lock file if the locks PID (now stored in the nonce as well as a UUID) doesn't point to the current process or the lock is older than the current process. This ensures that even if Juju starts with the same PID as it had previously we can still detect that the lock is stale.

(Review request: http://reviews.vapour.ws/r/2854/)