### PR TITLE
Switch to using gopkg.in/yaml.v2

### DIFF
--- a/trivial.go
+++ b/trivial.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"unicode"
 
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 )
 
 // WriteYaml marshals obj as yaml and then writes it to a file, atomically,


### PR DESCRIPTION
The helper actually using yaml is unfortunately untested, but uses none of the new interface parts.

(Review request: http://reviews.vapour.ws/r/2874/)