### PR TITLE
Revert "Merge pull request #159 from dooferlad/clean-stale-locks"

### DIFF
--- a/fslock/fslock.go
+++ b/fslock/fslock.go
@@ -1,7 +1,7 @@
 // Copyright 2013 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
-// Package fslock is an on-disk mutex protecting a resource
+// On-disk mutex protecting a resource
 //
 // A lock is represented on disk by a directory of a particular name,
 // containing an information file.  Taking a lock is done by renaming a
@@ -17,14 +17,12 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"path/filepath"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/juju/loggo"
+
 	"github.com/juju/utils"
-	"gopkg.in/mgo.v2/bson"
 )
 
 const (
@@ -50,12 +48,6 @@ type Lock struct {
 	nonce  []byte
 }
 
-// Nonce holds data that is unique to this lock
-type Nonce struct {
-	PID  int
-	UUID []byte
-}
-
 // NewLock returns a new lock with the given name within the given lock
 // directory, without acquiring it. The lock name must match the regular
 // expression defined by NameRegexp.
@@ -63,15 +55,7 @@ func NewLock(lockDir, name string) (*Lock, error) {
 	if !validName.MatchString(name) {
 		return nil, fmt.Errorf("Invalid lock name %q.  Names must match %q", name, NameRegexp)
 	}
-	uuid, err := utils.NewUUID()
-	if err != nil {
-		return nil, err
-	}
-	nonceParts := Nonce{
-		PID:  os.Getpid(),
-		UUID: uuid[:],
-	}
-	nonce, err := bson.Marshal(nonceParts)
+	nonce, err := utils.NewUUID()
 	if err != nil {
 		return nil, err
 	}
@@ -166,78 +150,12 @@ func (lock *Lock) lockLoop(message string, continueFunc func() error) error {
 	}
 }
 
-// clean reads the lock and checks that it is valid. If the lock points to a running
-// juju process that is older than the lock file, the lock is left in place, else
-// the lock is removed.
-func (lock *Lock) clean() error {
-	// If a lock exists, see if it is stale
-	heldNonce, err := ioutil.ReadFile(lock.heldFile())
-	if err != nil {
-		// No lock or we can't read it, so nothing to do/that we can do
-		logger.Tracef("No lock to clean")
-		return nil
-	}
-
-	// There is a lock...
-	var nonce Nonce
-	err = bson.Unmarshal(heldNonce, &nonce)
-	if err != nil {
-		// The lock should contain a BSON encoded Nonce object. If we can't decode
-		// it then we consider it garbage and just delete the lock.
-		logger.Debugf("Can't decode lock %s (%s): %s", lock.name, lock.Message(), err)
-		return lock.BreakLock()
-	}
-
-	procExeLink := fmt.Sprintf("/proc/%d/exe", nonce.PID)
-	path, err := filepath.EvalSymlinks(procExeLink)
-	if err != nil {
-		// If we can't read the symlink, it can't be a Juju process started by
-		// the same user (or something really bad is going on)
-		logger.Debugf("Lock is stale (can't read exe symlink) %s (%s): %s", lock.name, lock.Message(), err)
-		return lock.BreakLock()
-	}
-
-	exe := filepath.Base(path)
-	if exe != "juju" && !strings.HasSuffix(exe, ".test") {
-		// If the process isn't Juju (or the test process), the lock is stale and we can break it safely.
-		logger.Debugf("Lock is stale (exe isn't juju) %s (%s): %s", lock.name, lock.Message(), exe)
-		return lock.BreakLock()
-	}
-
-	// Lock is current and points to a running instance of Juju
-	procFileInfo, err := os.Lstat(procExeLink)
-	if err != nil {
-		logger.Debugf("Lock cleaner error -- can't os.Lstat(procExeLink) %s (%s): %s", lock.name, lock.Message(), err)
-		return err
-	}
-
-	lockFileInfo, err := os.Lstat(lock.heldFile())
-	if err != nil {
-		logger.Debugf("Lock cleaner error -- can't os.Lstat(lock.heldFile()) %s (%s): %s", lock.name, lock.Message(), err)
-		return err
-	}
-
-	if procFileInfo.ModTime().After(lockFileInfo.ModTime().Add(time.Second)) {
-		// If the process is newer than the lock, the lock is stale. The 1s fiddle is much more than is needed
-		// to prevent errant test failures (on dooferlad's dev box 50ms is plenty). It is fine to have this much
-		// margin for error though because this branch should only be taken when a PID has been recycled and that
-		// only happens when all 32k (/proc/sys/kernel/pid_max) have been used or the machine reboots.
-		logger.Debugf("Lock is stale (older then juju process) %s (%s)", lock.name, lock.Message())
-		return lock.BreakLock()
-	}
-
-	logger.Tracef("Lock is current %s (%s)", lock.name, lock.Message())
-	// lock is current. Do nothing.
-	return nil
-}
-
 // Lock blocks until it is able to acquire the lock.  Since we are dealing
 // with sharing and locking using the filesystem, it is good behaviour to
 // provide a message that is saved with the lock.  This is output in debugging
 // information, and can be queried by any other Lock dealing with the same
 // lock name and lock directory.
 func (lock *Lock) Lock(message string) error {
-	lock.clean()
 	// The continueFunc is effectively a no-op, causing continual looping
 	// until the lock is acquired.
 	continueFunc := func() error { return nil }


### PR DESCRIPTION
This reverts commit c73a4f676d7ef6f1c6e53642ed9f62efb3d4bb9a, reversing
changes made to 5f4ce83eb1440ceb90f8089520aa035b1281282b.

There are many issues with this branch.
 - assumes knowledge of juju, it shouldn't
 - assumes proc filesystem, it shouldn't
 - changes a uuid nonce (valid filename) into bson bytes (not valid filename)


(Review request: http://reviews.vapour.ws/r/2886/)