### PR TITLE
fslock: add NewLockWithClock function; maintain NewLock as backwardly compatible

### DIFF
--- a/fslock/fslock.go
+++ b/fslock/fslock.go
@@ -51,10 +51,9 @@ type Lock struct {
 	clock  clock.Clock
 }
 
-// NewLock returns a new lock with the given name within the given lock
-// directory, without acquiring it. The lock name must match the regular
-// expression defined by NameRegexp.
-func NewLock(lockDir, name string, clock clock.Clock) (*Lock, error) {
+// NewLockWithClock is like NewLock but uses the given clock
+// to enable faking time passing.
+func NewLockWithClock(lockDir, name string, clock clock.Clock) (*Lock, error) {
 	if !validName.MatchString(name) {
 		return nil, fmt.Errorf("Invalid lock name %q.  Names must match %q", name, NameRegexp)
 	}
@@ -73,6 +72,13 @@ func NewLock(lockDir, name string, clock clock.Clock) (*Lock, error) {
 		return nil, err
 	}
 	return lock, nil
+}
+
+// NewLock returns a new lock with the given name within the given lock
+// directory, without acquiring it. The lock name must match the regular
+// expression defined by NameRegexp.
+func NewLock(lockDir, name string) (*Lock, error) {
+	return NewLockWithClock(lockDir, name, clock.WallClock)
 }
 
 func (lock *Lock) lockDir() string {

--- a/fslock/fslock_test.go
+++ b/fslock/fslock_test.go
@@ -54,7 +54,7 @@ func (s *fslockSuite) TestValidNamesLockDir(c *gc.C) {
 		"longer-with.special-characters",
 	} {
 		dir := c.MkDir()
-		_, err := fslock.NewLock(dir, name, &fastclock{c})
+		_, err := fslock.NewLockWithClock(dir, name, &fastclock{c})
 		c.Assert(err, gc.IsNil)
 	}
 }
@@ -72,7 +72,7 @@ func (s *fslockSuite) TestInvalidNames(c *gc.C) {
 		"no:colon",
 	} {
 		dir := c.MkDir()
-		_, err := fslock.NewLock(dir, name, &fastclock{c})
+		_, err := fslock.NewLockWithClock(dir, name, &fastclock{c})
 		c.Assert(err, gc.ErrorMatches, "Invalid lock name .*")
 	}
 }
@@ -81,7 +81,7 @@ func (s *fslockSuite) TestNewLockWithExistingDir(c *gc.C) {
 	dir := c.MkDir()
 	err := os.MkdirAll(dir, 0755)
 	c.Assert(err, gc.IsNil)
-	_, err = fslock.NewLock(dir, "special", &fastclock{c})
+	_, err = fslock.NewLockWithClock(dir, "special", &fastclock{c})
 	c.Assert(err, gc.IsNil)
 }
 
@@ -93,13 +93,13 @@ func (s *fslockSuite) TestNewLockWithExistingFileInPlace(c *gc.C) {
 	err = ioutil.WriteFile(path, []byte("foo"), 0644)
 	c.Assert(err, gc.IsNil)
 
-	_, err = fslock.NewLock(path, "special", &fastclock{c})
+	_, err = fslock.NewLockWithClock(path, "special", &fastclock{c})
 	c.Assert(err, gc.ErrorMatches, `.* not a directory`)
 }
 
 func (s *fslockSuite) TestIsLockHeldBasics(c *gc.C) {
 	dir := c.MkDir()
-	lock, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
 	c.Assert(lock.IsLockHeld(), gc.Equals, false)
 
@@ -114,9 +114,9 @@ func (s *fslockSuite) TestIsLockHeldBasics(c *gc.C) {
 
 func (s *fslockSuite) TestIsLockHeldTwoLocks(c *gc.C) {
 	dir := c.MkDir()
-	lock1, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock1, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
-	lock2, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock2, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
 
 	err = lock1.Lock("")
@@ -127,9 +127,9 @@ func (s *fslockSuite) TestIsLockHeldTwoLocks(c *gc.C) {
 func (s *fslockSuite) TestLockBlocks(c *gc.C) {
 
 	dir := c.MkDir()
-	lock1, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock1, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
-	lock2, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock2, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
 
 	acquired := make(chan struct{})
@@ -165,7 +165,7 @@ func (s *fslockSuite) TestLockBlocks(c *gc.C) {
 
 func (s *fslockSuite) TestLockWithTimeoutUnlocked(c *gc.C) {
 	dir := c.MkDir()
-	lock, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
 
 	err = lock.LockWithTimeout(shortWait, "")
@@ -174,9 +174,9 @@ func (s *fslockSuite) TestLockWithTimeoutUnlocked(c *gc.C) {
 
 func (s *fslockSuite) TestLockWithTimeoutLocked(c *gc.C) {
 	dir := c.MkDir()
-	lock1, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock1, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
-	lock2, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock2, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
 
 	err = lock1.Lock("")
@@ -188,7 +188,7 @@ func (s *fslockSuite) TestLockWithTimeoutLocked(c *gc.C) {
 
 func (s *fslockSuite) TestUnlock(c *gc.C) {
 	dir := c.MkDir()
-	lock, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
 
 	err = lock.Unlock()
@@ -197,9 +197,9 @@ func (s *fslockSuite) TestUnlock(c *gc.C) {
 
 func (s *fslockSuite) TestIsLocked(c *gc.C) {
 	dir := c.MkDir()
-	lock1, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock1, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
-	lock2, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock2, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
 
 	err = lock1.Lock("")
@@ -211,9 +211,9 @@ func (s *fslockSuite) TestIsLocked(c *gc.C) {
 
 func (s *fslockSuite) TestBreakLock(c *gc.C) {
 	dir := c.MkDir()
-	lock1, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock1, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
-	lock2, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock2, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
 
 	err = lock1.Lock("")
@@ -234,7 +234,7 @@ func (s *fslockSuite) TestBreakLock(c *gc.C) {
 
 func (s *fslockSuite) TestMessage(c *gc.C) {
 	dir := c.MkDir()
-	lock, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
 	c.Assert(lock.Message(), gc.Equals, "")
 
@@ -250,9 +250,9 @@ func (s *fslockSuite) TestMessage(c *gc.C) {
 
 func (s *fslockSuite) TestMessageAcrossLocks(c *gc.C) {
 	dir := c.MkDir()
-	lock1, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock1, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
-	lock2, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock2, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
 
 	err = lock1.Lock("very busy")
@@ -262,7 +262,7 @@ func (s *fslockSuite) TestMessageAcrossLocks(c *gc.C) {
 
 func (s *fslockSuite) TestInitialMessageWhenLocking(c *gc.C) {
 	dir := c.MkDir()
-	lock, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
 
 	err = lock.Lock("initial message")
@@ -292,7 +292,7 @@ func (s *fslockSuite) TestStress(c *gc.C) {
 
 	var stress = func(name string) {
 		defer func() { done <- struct{}{} }()
-		lock, err := fslock.NewLock(dir, "testing", &fastclock{c})
+		lock, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 		if err != nil {
 			c.Errorf("Failed to create a new lock")
 			return
@@ -329,7 +329,7 @@ func (s *fslockSuite) TestTomb(c *gc.C) {
 	die := tomb.Tomb{}
 
 	dir := c.MkDir()
-	lock, err := fslock.NewLock(dir, "testing", &fastclock{c})
+	lock, err := fslock.NewLockWithClock(dir, "testing", &fastclock{c})
 	c.Assert(err, gc.IsNil)
 	// Just use one lock, and try to lock it twice.
 	err = lock.Lock("very busy")


### PR DESCRIPTION
Because NewLock had been changed backwardly incompatibly, it broke
any clients that used it unnecessarily. This maintains the old API
(which is more convenient for most clients) but adds the new functionality
using a new entry point.

(Review request: http://reviews.vapour.ws/r/2996/)