### PR TITLE
Added a timer to the utils package

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -9,5 +9,4 @@ var (
 	Dial              = dial
 	NetDial           = &netDial
 	ResolveSudoByFunc = resolveSudo
-	AfterFunc         = &afterFunc
 )

--- a/export_test.go
+++ b/export_test.go
@@ -15,12 +15,6 @@ var (
 	ResolveSudoByFunc = resolveSudo
 )
 
-func NewTestBackoffTimer(info BackoffTimerInfo, mockAfterFunc func(d time.Duration, f func()) StoppableTimer) *BackoffTimer {
-	timer := NewBackoffTimer(info)
-	timer.afterFunc = mockAfterFunc
-	return timer
-}
-
 func ExposeBackoffTimerDuration(bot *BackoffTimer) time.Duration {
 	return bot.currentDuration
 }

--- a/export_test.go
+++ b/export_test.go
@@ -9,4 +9,5 @@ var (
 	Dial              = dial
 	NetDial           = &netDial
 	ResolveSudoByFunc = resolveSudo
+	AfterFunc         = &afterFunc
 )

--- a/export_test.go
+++ b/export_test.go
@@ -3,6 +3,10 @@
 
 package utils
 
+import (
+	"time"
+)
+
 var (
 	GOMAXPROCS        = &gomaxprocs
 	NumCPU            = &numCPU
@@ -10,3 +14,13 @@ var (
 	NetDial           = &netDial
 	ResolveSudoByFunc = resolveSudo
 )
+
+func NewTestBackoffTimer(info BackoffTimerInfo, mockAfterFunc func(d time.Duration, f func()) StoppableTimer) *BackoffTimer {
+	timer := NewBackoffTimer(info)
+	timer.afterFunc = mockAfterFunc
+	return timer
+}
+
+func ExposeBackoffTimerDuration(bot *BackoffTimer) time.Duration {
+	return bot.currentDuration
+}

--- a/timer.go
+++ b/timer.go
@@ -24,7 +24,7 @@ type Countdown interface {
 	Start()
 }
 
-// NewBackoffTimer creates and initializer a new BackoffTimer
+// NewBackoffTimer creates and initializes a new BackoffTimer
 // A backoff timer starts at min and gets multiplied by factor
 // until it reaches max. Jitter determines whether a small
 // randomization is added to the duration.
@@ -38,7 +38,7 @@ func NewBackoffTimer(info BackoffTimerInfo) *BackoffTimer {
 	}
 }
 
-// BackoffTimer creates and initializer a new BackoffTimer
+// BackoffTimer implements Countdown.
 // A backoff timer starts at min and gets multiplied by factor
 // until it reaches max. Jitter determines whether a small
 // randomization is added to the duration.
@@ -71,7 +71,7 @@ type BackoffTimerInfo struct {
 	Func func()
 }
 
-// Signal implements the Timer interface
+// Signal implements the Timer interface.
 // Any existing timer execution is stopped before
 // a new one is created.
 func (t *BackoffTimer) Start() {
@@ -85,7 +85,7 @@ func (t *BackoffTimer) Start() {
 	t.increaseDuration()
 }
 
-// Reset implements the Timer interface
+// Reset implements the Timer interface.
 func (t *BackoffTimer) Reset() {
 	if t.timer != nil {
 		t.timer.Stop()
@@ -102,7 +102,7 @@ func (t *BackoffTimer) increaseDuration() {
 	current := int64(t.currentDuration)
 	nextDuration := time.Duration(current * t.info.Factor)
 	if t.info.Jitter {
-		// Get a factor in [-1; 1]
+		// Get a factor in [-1; 1].
 		randFactor := (rand.Float64() * 2) - 1
 		jitter := float64(nextDuration) * randFactor * 0.03
 		nextDuration = nextDuration + time.Duration(jitter)

--- a/timer.go
+++ b/timer.go
@@ -1,0 +1,127 @@
+// Copyright 2015 Canonical Ltd.
+// Copyright 2015 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils
+
+import (
+	"math/rand"
+	"time"
+)
+
+// Timer implements a timer that will signal after a
+// internally stored duration. The steps as well as min and max
+// durations are declared upon initialization and depend on
+// the particular implementation
+type Timer interface {
+	// Channel returns the channel that can be listened for events.
+	Channel() <-chan struct{}
+
+	// Reset will reset the timer to it's minimum value
+	// and stop any existing timer.
+	Reset()
+
+	// Signal will send a signal on the channel returned by Channel
+	// after a internally stored duration and increase the duration
+	// for the next call. Only one signal can be pending to be sent
+	// at a time.
+	Signal()
+}
+
+// NewBackoffTimer creates and initializer a new BackoffTimer
+// A backoff timer starts at min and gets multiplied by factor
+// until it reaches max. Jitter determines whether a small
+// randomization is added to the duration.
+func NewBackoffTimer(min, max time.Duration, jitter bool, factor int64) Timer {
+	return &BackoffTimer{
+		Min:             min,
+		Max:             max,
+		Jitter:          jitter,
+		Factor:          factor,
+		Chan:            make(chan struct{}, 1),
+		CurrentDuration: min,
+	}
+}
+
+// BackoffTimer creates and initializer a new BackoffTimer
+// A backoff timer starts at min and gets multiplied by factor
+// until it reaches max. Jitter determines whether a small
+// randomization is added to the duration.
+// The struct is mainly exposed for testing purposes.
+type BackoffTimer struct {
+	Timer StdTimer
+
+	Min    time.Duration
+	Max    time.Duration
+	Jitter bool
+	Factor int64
+
+	Chan chan struct{}
+
+	CurrentDuration time.Duration
+}
+
+// Channel implements the Timer interface
+func (t *BackoffTimer) Channel() <-chan struct{} {
+	return t.Chan
+}
+
+// Signal implements the Timer interface
+// Any existing timer execution is stopped before
+// a new one is created.
+func (t *BackoffTimer) Signal() {
+	if t.Timer != nil {
+		t.Timer.Stop()
+	}
+	t.Timer = afterFunc(t.CurrentDuration, func() {
+		t.Chan <- struct{}{}
+	})
+	// Since it's a backoff timer we will increase
+	// the duration after each signal.
+	t.increaseDuration()
+}
+
+// increaseDuration will increase the duration based on
+// the current value and the factor. If jitter is true
+// it will add a 0.3% jitter to the final value.
+func (t *BackoffTimer) increaseDuration() {
+	current := int64(t.CurrentDuration)
+	nextDuration := time.Duration(current * t.Factor)
+	if t.Jitter {
+		// Get a factor in [-1; 1]
+		randFactor := (rand.Float64() * 2) - 1
+		jitter := float64(nextDuration) * randFactor * 0.03
+		nextDuration = nextDuration + time.Duration(jitter)
+	}
+	if nextDuration > t.Max {
+		nextDuration = t.Max
+	}
+	t.CurrentDuration = nextDuration
+}
+
+// Reset implements the Timer interface
+func (t *BackoffTimer) Reset() {
+	if t.Timer != nil {
+		t.Timer.Stop()
+	}
+	if t.CurrentDuration > t.Min {
+		t.CurrentDuration = t.Min
+	}
+}
+
+// StdTimer defines a interface for time.Timer
+// so it's easier to mock it in tests
+type StdTimer interface {
+	// Reset changes the timer to expire after duration d. It returns true
+	// if the timer had been active, false if the timer had expired or been stopped.
+	Reset(time.Duration) bool
+
+	// Stop prevents the Timer from firing. It returns true if the call stops the timer,
+	// false if the timer has already expired or been stopped. Stop does not close the
+	// channel, to prevent a read from the channel succeeding incorrectly.
+	Stop() bool
+}
+
+var afterFunc = func(d time.Duration, f func()) StdTimer {
+	return time.AfterFunc(d, f)
+}

--- a/timer_test.go
+++ b/timer_test.go
@@ -1,0 +1,147 @@
+// Copyright 2015 Canonical Ltd.
+// Copyright 2015 Cloudbase Solutions SRL
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package utils_test
+
+import (
+	"math"
+	"time"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/testing"
+	"github.com/juju/utils"
+)
+
+type TestStdTimer struct {
+	stdStub *testing.Stub
+}
+
+func (t *TestStdTimer) Stop() bool {
+	t.stdStub.AddCall("Stop")
+	return true
+}
+
+func (t *TestStdTimer) Reset(d time.Duration) bool {
+	t.stdStub.AddCall("Reset", d)
+	return true
+}
+
+type timerSuite struct {
+	baseSuite      testing.CleanupSuite
+	timer          utils.BackoffTimer
+	afterFuncCalls int64
+	stub           *testing.Stub
+
+	min    time.Duration
+	max    time.Duration
+	factor int64
+}
+
+var _ = gc.Suite(&timerSuite{})
+
+func (s *timerSuite) SetUpTest(c *gc.C) {
+	s.baseSuite.SetUpTest(c)
+	s.afterFuncCalls = 0
+	s.stub = &testing.Stub{}
+	s.baseSuite.PatchValue(utils.AfterFunc, func(d time.Duration, f func()) utils.StdTimer {
+		s.afterFuncCalls++
+		return &TestStdTimer{s.stub}
+	})
+
+	s.min = 2 * time.Second
+	s.max = 16 * time.Second
+	s.factor = 2
+	s.timer = utils.BackoffTimer{
+		Min:             s.min,
+		Max:             s.max,
+		Jitter:          false,
+		Factor:          s.factor,
+		Chan:            make(chan struct{}, 1),
+		CurrentDuration: s.min,
+	}
+}
+
+func (s *timerSuite) TestSignal(c *gc.C) {
+	s.timer.Signal()
+	s.testSignal(c, 1, 1)
+}
+
+func (s *timerSuite) TestMultipleSignals(c *gc.C) {
+	s.timer.Signal()
+	s.testSignal(c, 1, 1)
+
+	s.timer.Signal()
+	s.checkStopCalls(c, 1)
+	s.testSignal(c, 2, 2)
+
+	s.timer.Signal()
+	s.checkStopCalls(c, 2)
+	s.testSignal(c, 3, 3)
+}
+
+func (s *timerSuite) TestResetNoSignal(c *gc.C) {
+	s.timer.Reset()
+	c.Assert(s.timer.CurrentDuration, gc.Equals, s.min)
+}
+
+func (s *timerSuite) TestResetAndSignal(c *gc.C) {
+	s.timer.Reset()
+	c.Assert(s.timer.CurrentDuration, gc.Equals, s.min)
+
+	// These variables are used to track the number
+	// of afterFuncCalls(signalCallsNo) and the number
+	// of Stop calls(resetStopCallsNo + signalCallsNo)
+	resetStopCallsNo := 0
+	signalCallsNo := 0
+
+	signalCallsNo++
+	s.timer.Signal()
+	s.testSignal(c, 1, 1)
+
+	resetStopCallsNo++
+	s.timer.Reset()
+	s.checkStopCalls(c, resetStopCallsNo+signalCallsNo-1)
+	c.Assert(s.timer.CurrentDuration, gc.Equals, s.min)
+
+	for i := 1; i < 200; i++ {
+		signalCallsNo++
+		s.timer.Signal()
+		s.testSignal(c, int64(signalCallsNo), int64(i))
+		s.checkStopCalls(c, resetStopCallsNo+signalCallsNo-1)
+	}
+
+	resetStopCallsNo++
+	s.timer.Reset()
+	s.checkStopCalls(c, signalCallsNo+resetStopCallsNo-1)
+
+	for i := 1; i < 100; i++ {
+		signalCallsNo++
+		s.timer.Signal()
+		s.testSignal(c, int64(signalCallsNo), int64(i))
+		s.checkStopCalls(c, resetStopCallsNo+signalCallsNo-1)
+	}
+
+	resetStopCallsNo++
+	s.timer.Reset()
+	s.checkStopCalls(c, signalCallsNo+resetStopCallsNo-1)
+}
+
+func (s *timerSuite) testSignal(c *gc.C, afterFuncCalls int64, durationFactor int64) {
+	c.Assert(s.afterFuncCalls, gc.Equals, afterFuncCalls)
+	c.Logf("iteration %d", afterFuncCalls)
+	expectedDuration := time.Duration(math.Pow(float64(s.factor), float64(durationFactor))) * s.min
+	if expectedDuration > s.max || expectedDuration <= 0 {
+		expectedDuration = s.max
+	}
+	c.Assert(s.timer.CurrentDuration, gc.Equals, expectedDuration)
+}
+
+func (s *timerSuite) checkStopCalls(c *gc.C, number int) {
+	calls := make([]testing.StubCall, number)
+	for i := 0; i < number; i++ {
+		calls[i] = testing.StubCall{FuncName: "Stop"}
+	}
+	s.stub.CheckCalls(c, calls)
+}

--- a/timer_test.go
+++ b/timer_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
-    "github.com/juju/utils/clock"
+	"github.com/juju/utils/clock"
 )
 
 type TestStdTimer struct {
@@ -26,8 +26,8 @@ func (t *TestStdTimer) Stop() bool {
 }
 
 func (t *TestStdTimer) Reset(d time.Duration) bool {
-    t.stdStub.AddCall("Reset", d)
-    return true
+	t.stdStub.AddCall("Reset", d)
+	return true
 }
 
 type timerSuite struct {
@@ -45,10 +45,10 @@ type timerSuite struct {
 var _ = gc.Suite(&timerSuite{})
 
 type mockClock struct {
-    stub             *testing.Stub
-    c                *gc.C
-    afterFuncCalls   *int64
-    properFuncCalled bool
+	stub             *testing.Stub
+	c                *gc.C
+	afterFuncCalls   *int64
+	properFuncCalled bool
 }
 
 // These 2 methods are not used here but are needed to satisfy the intergface
@@ -56,11 +56,11 @@ func (c *mockClock) Now() time.Time                         { return time.Now() 
 func (c *mockClock) After(d time.Duration) <-chan time.Time { return time.After(d) }
 
 func (c *mockClock) AfterFunc(d time.Duration, f func()) clock.Timer {
-    *c.afterFuncCalls++
-    f()
-    c.c.Assert(c.properFuncCalled, jc.IsTrue)
-    c.properFuncCalled = false
-    return &TestStdTimer{c.stub}
+	*c.afterFuncCalls++
+	f()
+	c.c.Assert(c.properFuncCalled, jc.IsTrue)
+	c.properFuncCalled = false
+	return &TestStdTimer{c.stub}
 }
 
 func (s *timerSuite) SetUpTest(c *gc.C) {
@@ -72,26 +72,26 @@ func (s *timerSuite) SetUpTest(c *gc.C) {
 	// that mockFunc is indeed passed as the argument to afterFuncMock
 	// to be executed.
 	mockFunc := func() { s.properFuncCalled = true }
-    mockClock := &mockClock{
-        stub:             s.stub,
-        c:                c,
-        afterFuncCalls:   &s.afterFuncCalls,
-        properFuncCalled: s.properFuncCalled,
-    }
+	mockClock := &mockClock{
+		stub:             s.stub,
+		c:                c,
+		afterFuncCalls:   &s.afterFuncCalls,
+		properFuncCalled: s.properFuncCalled,
+	}
 
 	s.min = 2 * time.Second
 	s.max = 16 * time.Second
 	s.factor = 2
-    s.timer = utils.NewBackoffTimer(
-        utils.BackoffTimerConfig{
-            Min:    s.min,
-            Max:    s.max,
-            Jitter: false,
-            Factor: s.factor,
-            Func:   mockFunc,
-            Clock:  mockClock,
-        },
-    )
+	s.timer = utils.NewBackoffTimer(
+		utils.BackoffTimerConfig{
+			Min:    s.min,
+			Max:    s.max,
+			Jitter: false,
+			Factor: s.factor,
+			Func:   mockFunc,
+			Clock:  mockClock,
+		},
+	)
 }
 
 func (s *timerSuite) TestStart(c *gc.C) {

--- a/timer_test.go
+++ b/timer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+    "github.com/juju/utils/clock"
 )
 
 type TestStdTimer struct {
@@ -22,6 +23,11 @@ type TestStdTimer struct {
 func (t *TestStdTimer) Stop() bool {
 	t.stdStub.AddCall("Stop")
 	return true
+}
+
+func (t *TestStdTimer) Reset(d time.Duration) bool {
+    t.stdStub.AddCall("Reset", d)
+    return true
 }
 
 type timerSuite struct {
@@ -38,6 +44,25 @@ type timerSuite struct {
 
 var _ = gc.Suite(&timerSuite{})
 
+type mockClock struct {
+    stub             *testing.Stub
+    c                *gc.C
+    afterFuncCalls   *int64
+    properFuncCalled bool
+}
+
+// These 2 methods are not used here but are needed to satisfy the intergface
+func (c *mockClock) Now() time.Time                         { return time.Now() }
+func (c *mockClock) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+func (c *mockClock) AfterFunc(d time.Duration, f func()) clock.Timer {
+    *c.afterFuncCalls++
+    f()
+    c.c.Assert(c.properFuncCalled, jc.IsTrue)
+    c.properFuncCalled = false
+    return &TestStdTimer{c.stub}
+}
+
 func (s *timerSuite) SetUpTest(c *gc.C) {
 	s.baseSuite.SetUpTest(c)
 	s.afterFuncCalls = 0
@@ -47,27 +72,26 @@ func (s *timerSuite) SetUpTest(c *gc.C) {
 	// that mockFunc is indeed passed as the argument to afterFuncMock
 	// to be executed.
 	mockFunc := func() { s.properFuncCalled = true }
-	afterFuncMock := func(d time.Duration, f func()) utils.StoppableTimer {
-		s.afterFuncCalls++
-		f()
-		c.Assert(s.properFuncCalled, jc.IsTrue)
-		s.properFuncCalled = false
-		return &TestStdTimer{s.stub}
-	}
+    mockClock := &mockClock{
+        stub:             s.stub,
+        c:                c,
+        afterFuncCalls:   &s.afterFuncCalls,
+        properFuncCalled: s.properFuncCalled,
+    }
 
 	s.min = 2 * time.Second
 	s.max = 16 * time.Second
 	s.factor = 2
-	s.timer = utils.NewTestBackoffTimer(
-		utils.BackoffTimerInfo{
-			Min:    s.min,
-			Max:    s.max,
-			Jitter: false,
-			Factor: s.factor,
-			Func:   mockFunc,
-		},
-		afterFuncMock,
-	)
+    s.timer = utils.NewBackoffTimer(
+        utils.BackoffTimerConfig{
+            Min:    s.min,
+            Max:    s.max,
+            Jitter: false,
+            Factor: s.factor,
+            Func:   mockFunc,
+            Clock:  mockClock,
+        },
+    )
 }
 
 func (s *timerSuite) TestStart(c *gc.C) {

--- a/timer_test.go
+++ b/timer_test.go
@@ -45,19 +45,22 @@ func (s *timerSuite) SetUpTest(c *gc.C) {
 	s.baseSuite.SetUpTest(c)
 	s.afterFuncCalls = 0
 	s.stub = &testing.Stub{}
-	s.baseSuite.PatchValue(utils.AfterFunc, func(d time.Duration, f func()) utils.StdTimer {
+	afterFuncMock := func(d time.Duration, f func()) utils.StoppableTimer {
 		s.afterFuncCalls++
 		return &TestStdTimer{s.stub}
-	})
+	}
 
 	s.min = 2 * time.Second
 	s.max = 16 * time.Second
 	s.factor = 2
 	s.timer = utils.BackoffTimer{
-		Min:             s.min,
-		Max:             s.max,
-		Jitter:          false,
-		Factor:          s.factor,
+		Info: utils.BackoffTimerInfo{
+			Min:       s.min,
+			Max:       s.max,
+			Jitter:    false,
+			Factor:    s.factor,
+			AfterFunc: afterFuncMock,
+		},
 		Chan:            make(chan struct{}, 1),
 		CurrentDuration: s.min,
 	}

--- a/timer_test.go
+++ b/timer_test.go
@@ -61,35 +61,34 @@ func (s *timerSuite) SetUpTest(c *gc.C) {
 			Factor:    s.factor,
 			AfterFunc: afterFuncMock,
 		},
-		Chan:            make(chan struct{}, 1),
 		CurrentDuration: s.min,
 	}
 }
 
-func (s *timerSuite) TestSignal(c *gc.C) {
-	s.timer.Signal()
-	s.testSignal(c, 1, 1)
+func (s *timerSuite) TestStart(c *gc.C) {
+	s.timer.Start()
+	s.testStart(c, 1, 1)
 }
 
-func (s *timerSuite) TestMultipleSignals(c *gc.C) {
-	s.timer.Signal()
-	s.testSignal(c, 1, 1)
+func (s *timerSuite) TestMultipleStarts(c *gc.C) {
+	s.timer.Start()
+	s.testStart(c, 1, 1)
 
-	s.timer.Signal()
+	s.timer.Start()
 	s.checkStopCalls(c, 1)
-	s.testSignal(c, 2, 2)
+	s.testStart(c, 2, 2)
 
-	s.timer.Signal()
+	s.timer.Start()
 	s.checkStopCalls(c, 2)
-	s.testSignal(c, 3, 3)
+	s.testStart(c, 3, 3)
 }
 
-func (s *timerSuite) TestResetNoSignal(c *gc.C) {
+func (s *timerSuite) TestResetNoStart(c *gc.C) {
 	s.timer.Reset()
 	c.Assert(s.timer.CurrentDuration, gc.Equals, s.min)
 }
 
-func (s *timerSuite) TestResetAndSignal(c *gc.C) {
+func (s *timerSuite) TestResetAndStart(c *gc.C) {
 	s.timer.Reset()
 	c.Assert(s.timer.CurrentDuration, gc.Equals, s.min)
 
@@ -100,8 +99,8 @@ func (s *timerSuite) TestResetAndSignal(c *gc.C) {
 	signalCallsNo := 0
 
 	signalCallsNo++
-	s.timer.Signal()
-	s.testSignal(c, 1, 1)
+	s.timer.Start()
+	s.testStart(c, 1, 1)
 
 	resetStopCallsNo++
 	s.timer.Reset()
@@ -110,8 +109,8 @@ func (s *timerSuite) TestResetAndSignal(c *gc.C) {
 
 	for i := 1; i < 200; i++ {
 		signalCallsNo++
-		s.timer.Signal()
-		s.testSignal(c, int64(signalCallsNo), int64(i))
+		s.timer.Start()
+		s.testStart(c, int64(signalCallsNo), int64(i))
 		s.checkStopCalls(c, resetStopCallsNo+signalCallsNo-1)
 	}
 
@@ -121,8 +120,8 @@ func (s *timerSuite) TestResetAndSignal(c *gc.C) {
 
 	for i := 1; i < 100; i++ {
 		signalCallsNo++
-		s.timer.Signal()
-		s.testSignal(c, int64(signalCallsNo), int64(i))
+		s.timer.Start()
+		s.testStart(c, int64(signalCallsNo), int64(i))
 		s.checkStopCalls(c, resetStopCallsNo+signalCallsNo-1)
 	}
 
@@ -131,7 +130,7 @@ func (s *timerSuite) TestResetAndSignal(c *gc.C) {
 	s.checkStopCalls(c, signalCallsNo+resetStopCallsNo-1)
 }
 
-func (s *timerSuite) testSignal(c *gc.C, afterFuncCalls int64, durationFactor int64) {
+func (s *timerSuite) testStart(c *gc.C, afterFuncCalls int64, durationFactor int64) {
 	c.Assert(s.afterFuncCalls, gc.Equals, afterFuncCalls)
 	c.Logf("iteration %d", afterFuncCalls)
 	expectedDuration := time.Duration(math.Pow(float64(s.factor), float64(durationFactor))) * s.min


### PR DESCRIPTION
This PR adds a timer implementation to the utils package.

This is supposed to be used inside uniter in a PR that is coming soon™. This is mostly the reason for how the interface has been designed, since it has to send a signal on some channel after a while. It is mostly a big wrapper around golang's AfterFunc.

http://reviews.vapour.ws/r/3010/