### PR TITLE
Add AfterFunc to clock

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -28,9 +28,8 @@ func Alarm(c Clock, t time.Time) <-chan time.Time {
 	return c.After(t.Sub(c.Now()))
 }
 
-// The Timer type represents a single event. When the Timer expires,
-// the current time will be sent on C, unless the Timer was created by AfterFunc.
-// A Timer must be created with NewTimer or AfterFunc.
+// The Timer type represents a single event.
+// A Timer must be created with AfterFunc.
 // This interface follows time.Timer's methods but provides easier mocking.
 type Timer interface {
 

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -14,6 +14,10 @@ type Clock interface {
 	// After waits for the duration to elapse and then sends the
 	// current time on the returned channel.
 	After(time.Duration) <-chan time.Time
+
+	// AfterFunc waits for the duration to elapse and then calls f in its own goroutine.
+	// It returns a Timer that can be used to cancel the call using its Stop method.
+	AfterFunc(time.Duration, func()) Timer
 }
 
 // Alarm returns a channel that will have the time sent on it at some point
@@ -22,4 +26,22 @@ type Clock interface {
 // This is short for c.After(t.Sub(c.Now())).
 func Alarm(c Clock, t time.Time) <-chan time.Time {
 	return c.After(t.Sub(c.Now()))
+}
+
+// The Timer type represents a single event. When the Timer expires,
+// the current time will be sent on C, unless the Timer was created by AfterFunc.
+// A Timer must be created with NewTimer or AfterFunc.
+// This interface follows time.Timer's methods but provides easier mocking.
+type Timer interface {
+
+	// Reset changes the timer to expire after duration d.
+	// It returns true if the timer had been active, false if
+	// the timer had expired or been stopped.
+	Reset(time.Duration) bool
+
+	// Stop prevents the Timer from firing. It returns true if
+	// the call stops the timer, false if the timer has already expired or been stopped.
+	// Stop does not close the channel, to prevent a read
+	// from the channel succeeding incorrectly.
+	Stop() bool
 }

--- a/clock/wall.go
+++ b/clock/wall.go
@@ -23,3 +23,7 @@ func (wallClock) Now() time.Time {
 func (wallClock) After(d time.Duration) <-chan time.Time {
 	return time.After(d)
 }
+
+func (wallClock) AfterFunc(d time.Duration, f func()) Timer {
+	return time.AfterFunc(d, f)
+}

--- a/fslock/fslock_test.go
+++ b/fslock/fslock_test.go
@@ -16,6 +16,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"launchpad.net/tomb"
 
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/fslock"
 )
 
@@ -42,6 +43,11 @@ func (*fastclock) Now() time.Time {
 func (f *fastclock) After(duration time.Duration) <-chan time.Time {
 	f.c.Check(duration, gc.Equals, fslock.LockWaitDelay)
 	return time.After(time.Millisecond)
+}
+
+func (f *fastclock) AfterFunc(duration time.Duration, function func()) clock.Timer {
+	f.c.Check(duration, gc.Equals, fslock.LockWaitDelay)
+	return time.AfterFunc(time.Millisecond, function)
 }
 
 // This test also happens to test that locks can get created when the parent


### PR DESCRIPTION
Pretty much what it says on the box.

Since this is mostly intended to aid in testing, an additional interface for *time.Timer has been added.

(Review request: http://reviews.vapour.ws/r/3076/)