### PR TITLE
series: add win2016 and nano series

### DIFF
--- a/series/export_windows_test.go
+++ b/series/export_windows_test.go
@@ -6,5 +6,6 @@ package series
 
 var (
 	CurrentVersionKey = &currentVersionKey
+	IsNanoKey         = &isNanoKey
 	ReadSeries        = readSeries
 )

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -143,6 +143,21 @@ var windowsNanoVersions = map[string]string{
 	"Windows Server 2016": "win2016nano",
 }
 
+// IsWindowsNano tells us whether the provided series is a
+// nano series. It may seem futile at this point, but more
+// nano series will come up with time.
+// This is here and not in a windows specific package
+// because we might want to take decisions dependant on
+// whether we have a nano series or not in more general code.
+func IsWindowsNano(series string) bool {
+	for _, val := range windowsNanoVersions {
+		if val == series {
+			return true
+		}
+	}
+	return false
+}
+
 // GetOSFromSeries will return the operating system based
 // on the series that is passed to it
 func GetOSFromSeries(series string) (os.OSType, error) {

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -67,6 +67,8 @@ var seriesVersions = map[string]string{
 	"win2012hv":   "win2012hv",
 	"win2012r2":   "win2012r2",
 	"win2012":     "win2012",
+	"win2016":     "win2016",
+	"win2016nano": "win2016nano",
 	"win7":        "win7",
 	"win8":        "win8",
 	"win81":       "win81",
@@ -106,6 +108,7 @@ var windowsVersionMatchOrder = []string{
 	"Hyper-V Server 2012",
 	"Windows Server 2012 R2",
 	"Windows Server 2012",
+	"Windows Server 2016",
 	"Windows Storage Server 2012 R2",
 	"Windows Storage Server 2012",
 	"Windows 7",
@@ -121,12 +124,23 @@ var windowsVersions = map[string]string{
 	"Hyper-V Server 2012":            "win2012hv",
 	"Windows Server 2012 R2":         "win2012r2",
 	"Windows Server 2012":            "win2012",
+	"Windows Server 2016":            "win2016",
 	"Windows Storage Server 2012 R2": "win2012r2",
 	"Windows Storage Server 2012":    "win2012",
 	"Windows 7":                      "win7",
 	"Windows 8.1":                    "win81",
 	"Windows 8":                      "win8",
 	"Windows 10":                     "win10",
+}
+
+// windowsNanoVersions is a mapping from the product name
+// stored in registry to a juju defined nano-series
+// On the nano version so far the product name actually
+// is identical to the correspondent main windows version
+// and the information about it being nano is stored in
+// a different place.
+var windowsNanoVersions = map[string]string{
+	"Windows Server 2016": "win2016nano",
 }
 
 // GetOSFromSeries will return the operating system based
@@ -145,6 +159,11 @@ func GetOSFromSeries(series string) (os.OSType, error) {
 		return os.Arch, nil
 	}
 	for _, val := range windowsVersions {
+		if val == series {
+			return os.Windows, nil
+		}
+	}
+	for _, val := range windowsNanoVersions {
 		if val == series {
 			return os.Windows, nil
 		}

--- a/series/supportedseries_test.go
+++ b/series/supportedseries_test.go
@@ -118,3 +118,19 @@ func (s *supportedSeriesSuite) TestSeriesVersionEmpty(c *gc.C) {
 	_, err := series.SeriesVersion("")
 	c.Assert(err, gc.ErrorMatches, `.*unknown version for series: "".*`)
 }
+
+func (s *supportedSeriesSuite) TestIsWindowsNano(c *gc.C) {
+	var isWindowsNanoTests = []struct {
+		series   string
+		expected bool
+	}{
+		{"win2016nano", true},
+		{"win2016", false},
+		{"win2012r2", false},
+		{"trusty", false},
+	}
+
+	for _, t := range isWindowsNanoTests {
+		c.Assert(series.IsWindowsNano(t.series), gc.Equals, t.expected)
+	}
+}

--- a/series/supportedseries_test.go
+++ b/series/supportedseries_test.go
@@ -35,6 +35,9 @@ var getOSFromSeriesTests = []struct {
 	series: "win2012r2",
 	want:   os.Windows,
 }, {
+	series: "win2016nano",
+	want:   os.Windows,
+}, {
 	series: "mountainlion",
 	want:   os.OSX,
 }, {
@@ -69,12 +72,13 @@ func (s *supportedSeriesSuite) TestUnknownOSFromSeries(c *gc.C) {
 
 func setSeriesTestData() {
 	series.SetSeriesVersions(map[string]string{
-		"trusty":  "14.04",
-		"utopic":  "14.10",
-		"win7":    "win7",
-		"win81":   "win81",
-		"centos7": "centos7",
-		"arch":    "rolling",
+		"trusty":      "14.04",
+		"utopic":      "14.10",
+		"win7":        "win7",
+		"win81":       "win81",
+		"win2016nano": "win2016nano",
+		"centos7":     "centos7",
+		"arch":        "rolling",
 	})
 }
 
@@ -83,7 +87,7 @@ func (s *supportedSeriesSuite) TestOSSupportedSeries(c *gc.C) {
 	supported := series.OSSupportedSeries(os.Ubuntu)
 	c.Assert(supported, jc.SameContents, []string{"trusty", "utopic"})
 	supported = series.OSSupportedSeries(os.Windows)
-	c.Assert(supported, jc.SameContents, []string{"win7", "win81"})
+	c.Assert(supported, jc.SameContents, []string{"win7", "win81", "win2016nano"})
 	supported = series.OSSupportedSeries(os.CentOS)
 	c.Assert(supported, jc.SameContents, []string{"centos7"})
 	supported = series.OSSupportedSeries(os.Arch)

--- a/series/supportedseries_windows_test.go
+++ b/series/supportedseries_windows_test.go
@@ -45,6 +45,8 @@ func (s *supportedSeriesWindowsSuite) TestSupportedSeries(c *gc.C) {
 		"win2012hv",
 		"win2012hvr2",
 		"win2012r2",
+		"win2016",
+		"win2016nano",
 		"win7",
 		"win8",
 		"win81",


### PR DESCRIPTION
This PR adds series support for win 2016 and nano.

One thing to be aware of (it also appears in a comment) is that every windows server version will most likely have a complementary nano version from now on, so there is some code to work along this.

(Review request: http://reviews.vapour.ws/r/3164/)