### PR TITLE
lp1518128: Use net.JoinHostPort to join addr:host

### DIFF
--- a/ssh/ssh_gocrypto.go
+++ b/ssh/ssh_gocrypto.go
@@ -4,13 +4,13 @@
 package ssh
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
 	"os/user"
+	"strconv"
 	"strings"
 
 	"github.com/juju/errors"
@@ -59,7 +59,7 @@ func (c *GoCryptoClient) Command(host string, command []string, options *Options
 	return &Cmd{impl: &goCryptoCommand{
 		signers:      signers,
 		user:         user,
-		addr:         fmt.Sprintf("%s:%d", host, port),
+		addr:         net.JoinHostPort(host, strconv.Itoa(port)),
 		command:      shellCommand,
 		proxyCommand: proxyCommand,
 	}}


### PR DESCRIPTION
To properly handle IPv6, net.JoinHostPort should be
used, rather than fmt.Sprintf("%s:%d"...)

(Review request: http://reviews.vapour.ws/r/3215/)