### PR TITLE
Revert "Fix race."

### DIFF
--- a/fslock/fslock.go
+++ b/fslock/fslock.go
@@ -122,7 +122,6 @@ func NewLock(lockDir, name string, cfg LockConfig) (*Lock, error) {
 	if err := os.RemoveAll(lock.aliveFile(lock.PID)); err != nil {
 		return nil, err
 	}
-	lock.stopWritingAliveFile = make(chan struct{})
 	return lock, nil
 }
 
@@ -158,6 +157,8 @@ func (lock *Lock) isAlive(PID int) bool {
 // createAliveFile kicks off a gorouteine that creates a proof of life file
 // and keeps its timestamp current.
 func (lock *Lock) createAliveFile(dir string) {
+	lock.stopWritingAliveFile = make(chan struct{})
+
 	go func() {
 		aliveFile := lock.aliveFile(lock.PID)
 		for {


### PR DESCRIPTION
Reverts juju/utils#178

7e742fc4821e2eb3f2b2d91ddcc1bcce3ae97021 was not correct. It fixed the data race but avoiding overwriting the field in createAliveFile but did not solve the underlying invariant failure caused by createAfterFile being called more than once.

(Review request: http://reviews.vapour.ws/r/3228/)