### PR TITLE
fslock alive file now has much better control

### DIFF
--- a/fslock/export_test.go
+++ b/fslock/export_test.go
@@ -12,3 +12,7 @@ func IsAlive(lock *Lock, PID int) bool {
 func DeclareDead(lock *Lock) {
 	lock.declareDead()
 }
+
+func AliveFile(lock *Lock) string {
+	return lock.aliveFile(lock.PID)
+}

--- a/fslock/fslock.go
+++ b/fslock/fslock.go
@@ -201,6 +201,10 @@ func (lock *Lock) declareDead() {
 	case lock.stopWritingAliveFile <- struct{}{}:
 	default:
 	}
+	select {
+	case <-lock.startWritingAliveFile:
+	default:
+	}
 }
 
 // clean reads the lock and checks that it is valid. If the lock points to a running

--- a/fslock/fslock_test.go
+++ b/fslock/fslock_test.go
@@ -293,7 +293,7 @@ func (s *fslockSuite) TestInitialMessageWhenLocking(c *gc.C) {
 
 func (s *fslockSuite) TestStress(c *gc.C) {
 	const lockAttempts = 200
-	const concurrentLocks = 10
+	const concurrentLocks = 40
 
 	var counter = new(int64)
 	// Use atomics to update lockState to make sure the lock isn't held by

--- a/fslock/fslock_test.go
+++ b/fslock/fslock_test.go
@@ -6,6 +6,7 @@ package fslock_test
 import (
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path"
 	"runtime"
@@ -392,27 +393,68 @@ func (s *fslockSuite) TestCleanNoMatchingProcess(c *gc.C) {
 	assertCanLock(c, lock)
 }
 
+func checkAliveFile(aliveFile string, expectAlive bool) (tests int, dead bool) {
+	var misses int
+	for check := 0; check < 200; check++ {
+		runtime.Gosched()
+		time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
+		aliveInfo, err := os.Lstat(aliveFile)
+		if err != nil {
+			// Typically this is file not existing. Whatever the reason, just retry
+			misses++
+			if misses > 5 && expectAlive == false {
+				// Alive file isn't going to arrive. Stop testing.
+				break
+			}
+			continue
+		}
+		tests++
+		if time.Now().Sub(aliveInfo.ModTime()) > 500*time.Millisecond {
+			// Alive file is too old - lock is dead
+			dead = true
+			break
+		}
+		if tests > 5 && expectAlive {
+			// Alive file is being kept up to date. Stop testing.
+			break
+		}
+	}
+
+	return tests, dead
+}
+
 // TestProofOfLife checks that the alive file doesn't get older than 500ms. Normally
 // it can get older, but we crank up the refresh interval for testing.
 func (s *fslockSuite) TestProofOfLife(c *gc.C) {
 	s.lockConfig.WaitDelay = 20 * time.Millisecond
-	lock, _, dir := newLockedLock(c, s.lockConfig)
-	aliveFile := path.Join(dir, "testing", fmt.Sprintf("alive.%d", lock.PID))
+	lock, _, _ := newLockedLock(c, s.lockConfig)
+	aliveFile := fslock.AliveFile(lock)
 
-	tests := 0
-	for check := 0; check < 20; check++ {
-		aliveInfo, err := os.Lstat(aliveFile)
-		if err != nil {
-			// Typically this is file not existing. Whatever the reason, just retry
-			time.Sleep(50 * time.Millisecond)
-			continue
-		}
-
-		c.Assert(time.Now().Sub(aliveInfo.ModTime()), jc.DurationLessThan, 500*time.Millisecond)
-		tests++
-		time.Sleep(50 * time.Millisecond)
-	}
-
+	tests, dead := checkAliveFile(aliveFile, true)
 	// Make sure we actually spotted an alive file and checked its time.
-	c.Assert(tests > 1, gc.Equals, true)
+	c.Assert(tests, jc.GreaterThan, 1)
+	c.Assert(dead, jc.IsFalse)
+
+	// Unlock the lock - the alive file should stop being updated
+	lock.Unlock()
+	time.Sleep(500 * time.Millisecond)
+
+	tests, dead = checkAliveFile(aliveFile, false)
+	c.Assert(tests, gc.Equals, 0)
+	c.Assert(dead, jc.IsFalse)
+
+	// re-lock - alive file should start being updated again
+	err := lock.Lock("testing")
+	c.Assert(err, gc.IsNil)
+	tests, dead = checkAliveFile(aliveFile, true)
+	c.Assert(dead, jc.IsFalse)
+	c.Assert(tests, jc.GreaterThan, 1)
+
+	// Make the lock stale
+	fslock.DeclareDead(lock)
+	time.Sleep(500 * time.Millisecond)
+
+	tests, dead = checkAliveFile(aliveFile, false)
+	c.Assert(tests, gc.Equals, 1)
+	c.Assert(dead, jc.IsTrue)
 }


### PR DESCRIPTION
 * Turn on and off by channels
 * Retries when files can't be created or updated (normally because it
   is so early in the lock lifetime that the initial create/move process
   is still happening).
 * More comprehensive testing around new functionality

(Review request: http://reviews.vapour.ws/r/3238/)