### PR TITLE
series: add UpdateSeriesVersions

### DIFF
--- a/series/series_linux.go
+++ b/series/series_linux.go
@@ -25,7 +25,7 @@ func readSeries() (string, error) {
 	if err != nil {
 		return "unknown", err
 	}
-	updateSeriesVersions()
+	updateSeriesVersionsOnce()
 	return seriesFromOSRelease(values)
 }
 
@@ -63,11 +63,8 @@ func ReleaseVersion() string {
 	return release["VERSION_ID"]
 }
 
-func updateLocalSeriesVersions() {
-	err := updateDistroInfo()
-	if err != nil {
-		logger.Warningf("failed to update distro info: %v", err)
-	}
+func updateLocalSeriesVersions() error {
+	return updateDistroInfo()
 }
 
 var distroInfo = "/usr/share/distro-info/ubuntu.csv"

--- a/series/series_nonlinux.go
+++ b/series/series_nonlinux.go
@@ -12,5 +12,6 @@ func ReleaseVersion() string {
 	return ""
 }
 
-func updateLocalSeriesVersions() {
+func updateLocalSeriesVersions() error {
+	return nil
 }


### PR DESCRIPTION
Add a function, UpdateSeriesVersions, which will
refresh the supported series by reading ubuntu.csv
on Ubuntu, and do nothing on other platforms. This
will be used when upgrading Juju: we will upgrade
the distro-info package, and then call this function
to read it in.

(Review request: http://reviews.vapour.ws/r/3373/)