### PR TITLE
fixes bug #1515289

### DIFF
--- a/http.go
+++ b/http.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"time"
 )
 
 var insecureClient = (*http.Client)(nil)
@@ -69,23 +68,6 @@ func GetNonValidatingHTTPClient() *http.Client {
 			InsecureSkipVerify: true,
 		}),
 	}
-}
-
-// NewHttpTLSTransport returns a new http.Transport constructed with the TLS config
-// and the necessary parameters for Juju.
-func NewHttpTLSTransport(tlsConfig *tls.Config) *http.Transport {
-	// See https://code.google.com/p/go/issues/detail?id=4677
-	// We need to force the connection to close each time so that we don't
-	// hit the above Go bug.
-	transport := &http.Transport{
-		Proxy:               http.ProxyFromEnvironment,
-		TLSClientConfig:     tlsConfig,
-		DisableKeepAlives:   true,
-		Dial:                dial,
-		TLSHandshakeTimeout: 10 * time.Second,
-	}
-	registerFileProtocol(transport)
-	return transport
 }
 
 // BasicAuthHeader creates a header that contains just the "Authorization"

--- a/http.go
+++ b/http.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 )
 
 var insecureClient = (*http.Client)(nil)
@@ -77,9 +78,11 @@ func NewHttpTLSTransport(tlsConfig *tls.Config) *http.Transport {
 	// We need to force the connection to close each time so that we don't
 	// hit the above Go bug.
 	transport := &http.Transport{
-		TLSClientConfig:   tlsConfig,
-		DisableKeepAlives: true,
-		Dial:              dial,
+		Proxy:               http.ProxyFromEnvironment,
+		TLSClientConfig:     tlsConfig,
+		DisableKeepAlives:   true,
+		Dial:                dial,
+		TLSHandshakeTimeout: 10 * time.Second,
 	}
 	registerFileProtocol(transport)
 	return transport

--- a/tls_transport_go12.go
+++ b/tls_transport_go12.go
@@ -1,4 +1,4 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2016 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
 // +build !go1.3

--- a/tls_transport_go12.go
+++ b/tls_transport_go12.go
@@ -1,0 +1,29 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// +build !go1.3
+
+package utils
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+// NewHttpTLSTransport returns a new http.Transport constructed with the TLS config
+// and the necessary parameters for Juju.
+func NewHttpTLSTransport(tlsConfig *tls.Config) *http.Transport {
+	// See https://code.google.com/p/go/issues/detail?id=4677
+	// We need to force the connection to close each time so that we don't
+	// hit the above Go bug.
+	transport := &http.Transport{
+		Proxy:             http.ProxyFromEnvironment,
+		TLSClientConfig:   tlsConfig,
+		DisableKeepAlives: true,
+		Dial:              dial,
+		// Go 1.2 does not support the TLSHandshaketimeout
+		// TLSHandshakeTimeout: 10 * time.Second,
+	}
+	registerFileProtocol(transport)
+	return transport
+}

--- a/tls_transport_go13.go
+++ b/tls_transport_go13.go
@@ -1,4 +1,4 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2016 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
 // +build go1.3

--- a/tls_transport_go13.go
+++ b/tls_transport_go13.go
@@ -1,0 +1,29 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// +build go1.3
+
+package utils
+
+import (
+	"crypto/tls"
+	"net/http"
+	"time"
+)
+
+// NewHttpTLSTransport returns a new http.Transport constructed with the TLS config
+// and the necessary parameters for Juju.
+func NewHttpTLSTransport(tlsConfig *tls.Config) *http.Transport {
+	// See https://code.google.com/p/go/issues/detail?id=4677
+	// We need to force the connection to close each time so that we don't
+	// hit the above Go bug.
+	transport := &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		TLSClientConfig:     tlsConfig,
+		DisableKeepAlives:   true,
+		Dial:                dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+	registerFileProtocol(transport)
+	return transport
+}


### PR DESCRIPTION
We werent setting the proxy field in the HTTP transport struct, which is what
the http Client uses to figure out how to proxy... so of course, we weren't
respecting the environment proxy.  Oddly enough, tools download is the only logic
using this code.  (However a later patch I'm going to land will cause the metric
sender to use this code as well, since it's rolling its own tls transport, and
making the same mistakes.

Added a TLS handshake timeout identical to the one used by the default http client,
so behavior will be consistent with the default.

For reference, this is the default transport used by the http client:

```go
var DefaultTransport RoundTripper = &Transport{
        Proxy: ProxyFromEnvironment,
        Dial: (&net.Dialer{
                Timeout:   30 * time.Second,
                KeepAlive: 30 * time.Second,
        }).Dial,
        TLSHandshakeTimeout: 10 * time.Second,
}
```
(from https://golang.org/pkg/net/http/#DefaultTransport)

(Review request: http://reviews.vapour.ws/r/3529/)