### PR TITLE
Track size and hash even when there is an error.

### DIFF
--- a/hash/hash.go
+++ b/hash/hash.go
@@ -10,7 +10,10 @@ import (
 	"hash"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 )
+
+var logger = loggo.GetLogger("utils.hash")
 
 type hashSum struct {
 	raw hash.Hash

--- a/hash/reader_test.go
+++ b/hash/reader_test.go
@@ -46,7 +46,7 @@ func (s *ReaderSuite) TestHashingReaderReadEmpty(c *gc.C) {
 	data, err := ioutil.ReadAll(r)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.stub.CheckCallNames(c, "Read")
+	s.stub.CheckCallNames(c, "Read", "Write")
 	c.Check(string(data), gc.HasLen, 0)
 	c.Check(s.hBuffer.String(), gc.Equals, "")
 }
@@ -58,7 +58,7 @@ func (s *ReaderSuite) TestHashingReaderReadSmall(c *gc.C) {
 	data, err := ioutil.ReadAll(r)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.stub.CheckCallNames(c, "Read", "Write", "Read")
+	s.stub.CheckCallNames(c, "Read", "Write", "Read", "Write")
 	c.Check(string(data), gc.Equals, "spam")
 	c.Check(s.hBuffer.String(), gc.Equals, "spam")
 }
@@ -70,7 +70,7 @@ func (s *ReaderSuite) TestHashingReaderReadFileError(c *gc.C) {
 
 	_, err := ioutil.ReadAll(r)
 
-	s.stub.CheckCallNames(c, "Read")
+	s.stub.CheckCallNames(c, "Read", "Write")
 	c.Check(errors.Cause(err), gc.Equals, failure)
 	c.Check(s.hBuffer.String(), gc.Equals, "")
 }

--- a/hash/readerwriter.go
+++ b/hash/readerwriter.go
@@ -39,6 +39,7 @@ func (hw *HashingWriter) Write(data []byte) (int, error) {
 	n, err := hw.wrapped.Write(data)
 	if err != nil {
 		if _, err := hw.raw.Write(data[:n]); err != nil {
+			// The initial error takes precedence.
 			logger.Errorf("could not write to hash: %v", err)
 		}
 		// No trace because some callers, like ioutil.ReadAll(), won't work.
@@ -79,6 +80,7 @@ func (hr *HashingReader) Read(data []byte) (int, error) {
 	n, err := hr.wrapped.Read(data)
 	if err != nil {
 		if _, err := hr.raw.Write(data[:n]); err != nil {
+			// The initial error takes precedence.
 			logger.Errorf("could not write to hash: %v", err)
 		}
 		// No trace because some callers, like ioutil.ReadAll(), won't work.

--- a/hash/writer_test.go
+++ b/hash/writer_test.go
@@ -69,7 +69,7 @@ func (s *WriterSuite) TestHashingWriterWriteFileError(c *gc.C) {
 
 	_, err := w.Write([]byte("spam"))
 
-	s.stub.CheckCallNames(c, "Write")
+	s.stub.CheckCallNames(c, "Write", "Write")
 	c.Check(errors.Cause(err), gc.Equals, failure)
 }
 

--- a/size.go
+++ b/size.go
@@ -76,12 +76,9 @@ func (st *sizeTracker) Reset() {
 // op implements io.Reader/io.Writer.
 func (st *sizeTracker) op(data []byte) (n int, err error) {
 	n, err = st.rawOp(data)
-	if err != nil {
-		// No trace because some callers, like ioutil.ReadAll(), won't work.
-		return n, err
-	}
 	st.size += int64(n)
-	return n, nil
+	// No trace because some callers, like ioutil.ReadAll(), won't work.
+	return n, err
 }
 
 // SizingReader is a reader that tracks the number of bytes read.


### PR DESCRIPTION
Some readers/writers handle bytes in the same operation that they handle EOF.  This change accommodates them.

(Review request: http://reviews.vapour.ws/r/3572/)