### PR TITLE
Fix LP 1536378

### DIFF
--- a/fslock/fslock.go
+++ b/fslock/fslock.go
@@ -146,7 +146,7 @@ func (lock *Lock) isAlive(PID int) bool {
 	if PID == lock.PID {
 		return true
 	}
-	for misses := 0; misses < 0; misses++ {
+	for i := 0; i < 10; i++ {
 		aliveInfo, err := os.Lstat(lock.aliveFile(PID))
 		if err == nil {
 			return time.Now().Before(aliveInfo.ModTime().Add(lock.lividityTimeout))
@@ -202,15 +202,14 @@ func (lock *Lock) clean() error {
 		return nil
 	}
 
-	alive := lock.isAlive(lockInfo.PID)
-	if alive == false {
-		logger.Debugf("Lock dead")
-		return lock.BreakLock()
+	if lock.isAlive(lockInfo.PID) {
+		// lock is current. Do nothing.
+		logger.Debugf("Lock alive")
+		return nil
 	}
-	logger.Debugf("Lock alive")
 
-	// lock is current. Do nothing.
-	return nil
+	logger.Debugf("Lock dead")
+	return lock.BreakLock()
 }
 
 // If message is set, it will write the message to the lock directory as the


### PR DESCRIPTION
Fixes LP #1536378

The logic inside isAlive was wrong, it was never executing the wait loop
so if two independent processes called isAlive (via clean) then they would
both think the lock is stale and attempt to break it.

The number of loop iterations if the alive file cannot be read is set to
an arbitrary value which will limit the max delay in tying to lock a dead lock
to 300 seconds.

(Review request: http://reviews.vapour.ws/r/3585/)