### PR TITLE
utils: add RelativeURL function

### DIFF
--- a/relativeurl.go
+++ b/relativeurl.go
@@ -1,0 +1,62 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package utils
+
+import (
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+// RelativeURLPath returns a relative URL path that is lexically
+// equivalent to targpath when interpreted by url.URL.ResolveReference.
+// On success, the returned path will always be non-empty and relative
+// to basePath, even if basePath and targPath share no elements.
+//
+// It is assumed that both basePath and targPath are normalized
+// (have no . or .. elements).
+//
+// An error is returned if basePath or targPath are not absolute paths.
+func RelativeURLPath(basePath, targPath string) (string, error) {
+	if !strings.HasPrefix(basePath, "/") {
+		return "", errors.New("non-absolute base URL")
+	}
+	if !strings.HasPrefix(targPath, "/") {
+		return "", errors.New("non-absolute target URL")
+	}
+	baseParts := strings.Split(basePath, "/")
+	targParts := strings.Split(targPath, "/")
+
+	// For the purposes of dotdot, the last element of
+	// the paths are irrelevant. We save the last part
+	// of the target path for later.
+	lastElem := targParts[len(targParts)-1]
+	baseParts = baseParts[0 : len(baseParts)-1]
+	targParts = targParts[0 : len(targParts)-1]
+
+	// Find the common prefix between the two paths:
+	var i int
+	for ; i < len(baseParts); i++ {
+		if i >= len(targParts) || baseParts[i] != targParts[i] {
+			break
+		}
+	}
+	dotdotCount := len(baseParts) - i
+	targOnly := targParts[i:]
+	result := make([]string, 0, dotdotCount+len(targOnly)+1)
+	for i := 0; i < dotdotCount; i++ {
+		result = append(result, "..")
+	}
+	result = append(result, targOnly...)
+	result = append(result, lastElem)
+	final := strings.Join(result, "/")
+	if final == "" {
+		// If the final result is empty, the last element must
+		// have been empty, so the target was slash terminated
+		// and there were no previous elements, so "."
+		// is appropriate.
+		final = "."
+	}
+	return final, nil
+}

--- a/relativeurl_test.go
+++ b/relativeurl_test.go
@@ -1,0 +1,152 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package utils_test
+
+import (
+	"net/url"
+
+	jujutesting "github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils"
+)
+
+type relativeURLSuite struct {
+	jujutesting.LoggingSuite
+}
+
+var _ = gc.Suite(&relativeURLSuite{})
+
+var relativeURLTests = []struct {
+	base        string
+	target      string
+	expect      string
+	expectError string
+}{{
+	expectError: "non-absolute base URL",
+}, {
+	base:        "/foo",
+	expectError: "non-absolute target URL",
+}, {
+	base:        "foo",
+	expectError: "non-absolute base URL",
+}, {
+	base:        "/foo",
+	target:      "foo",
+	expectError: "non-absolute target URL",
+}, {
+	base:   "/foo",
+	target: "/bar",
+	expect: "bar",
+}, {
+	base:   "/foo/",
+	target: "/bar",
+	expect: "../bar",
+}, {
+	base:   "/bar",
+	target: "/foo/",
+	expect: "foo/",
+}, {
+	base:   "/foo/",
+	target: "/bar/",
+	expect: "../bar/",
+}, {
+	base:   "/foo/bar",
+	target: "/bar/",
+	expect: "../bar/",
+}, {
+	base:   "/foo/bar/",
+	target: "/bar/",
+	expect: "../../bar/",
+}, {
+	base:   "/foo/bar/baz",
+	target: "/foo/targ",
+	expect: "../targ",
+}, {
+	base:   "/foo/bar/baz/frob",
+	target: "/foo/bar/one/two/",
+	expect: "../one/two/",
+}, {
+	base:   "/foo/bar/baz/",
+	target: "/foo/targ",
+	expect: "../../targ",
+}, {
+	base:   "/foo/bar/baz/frob/",
+	target: "/foo/bar/one/two/",
+	expect: "../../one/two/",
+}, {
+	base:   "/foo/bar",
+	target: "/foot/bar",
+	expect: "../foot/bar",
+}, {
+	base:   "/foo/bar/baz/frob",
+	target: "/foo/bar",
+	expect: "../../bar",
+}, {
+	base:   "/foo/bar/baz/frob/",
+	target: "/foo/bar",
+	expect: "../../../bar",
+}, {
+	base:   "/foo/bar/baz/frob/",
+	target: "/foo/bar/",
+	expect: "../../",
+}, {
+	base:   "/foo/bar/baz",
+	target: "/foo/bar/other",
+	expect: "other",
+}, {
+	base:   "/foo/bar/",
+	target: "/foo/bar/",
+	expect: ".",
+}, {
+	base:   "/foo/bar",
+	target: "/foo/bar",
+	expect: "bar",
+}, {
+	base:   "/foo/bar/",
+	target: "/foo/bar/",
+	expect: ".",
+}, {
+	base:   "/foo/bar",
+	target: "/foo/",
+	expect: ".",
+}, {
+	base:   "/foo",
+	target: "/",
+	expect: ".",
+}, {
+	base:   "/foo/",
+	target: "/",
+	expect: "../",
+}, {
+	base:   "/foo/bar",
+	target: "/",
+	expect: "../",
+}, {
+	base:   "/foo/bar/",
+	target: "/",
+	expect: "../../",
+}}
+
+func (*relativeURLSuite) TestRelativeURL(c *gc.C) {
+	for i, test := range relativeURLTests {
+		c.Logf("test %d: %q %q", i, test.base, test.target)
+		// Sanity check the test itself.
+		if test.expectError == "" {
+			baseURL := &url.URL{Path: test.base}
+			expectURL := &url.URL{Path: test.expect}
+			targetURL := baseURL.ResolveReference(expectURL)
+			c.Check(targetURL.Path, gc.Equals, test.target, gc.Commentf("resolve reference failure (%q + %q != %q)", test.base, test.expect, test.target))
+		}
+
+		result, err := utils.RelativeURLPath(test.base, test.target)
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+			c.Assert(result, gc.Equals, "")
+		} else {
+			c.Assert(err, gc.IsNil)
+			c.Check(result, gc.Equals, test.expect)
+		}
+	}
+}


### PR DESCRIPTION
This is the inverse of URL.ResolveReference, useful for calculating
a relative URL when needed.

(Review request: http://reviews.vapour.ws/r/3591/)