### PR TITLE
1533262 - add wily and xenial to supported series

### DIFF
--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -63,6 +63,8 @@ var seriesVersions = map[string]string{
 	"trusty":      "14.04",
 	"utopic":      "14.10",
 	"vivid":       "15.04",
+	"wily":        "15.10",
+	"xenial":      "16.04",
 	"win2008r2":   "win2008r2",
 	"win2012hvr2": "win2012hvr2",
 	"win2012hv":   "win2012hv",
@@ -97,6 +99,8 @@ var ubuntuSeries = map[string]string{
 	"trusty":  "14.04",
 	"utopic":  "14.10",
 	"vivid":   "15.04",
+	"wily":    "15.10",
+	"xenial":  "16.04",
 }
 
 // Windows versions come in various flavors:

--- a/series/supportedseries_windows_test.go
+++ b/series/supportedseries_windows_test.go
@@ -5,8 +5,6 @@
 package series_test
 
 import (
-	"sort"
-
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -33,6 +31,7 @@ func (s *supportedSeriesWindowsSuite) TestSupportedSeries(c *gc.C) {
 	expectedSeries := []string{
 		"arch",
 		"centos7",
+
 		"precise",
 		"quantal",
 		"raring",
@@ -40,6 +39,9 @@ func (s *supportedSeriesWindowsSuite) TestSupportedSeries(c *gc.C) {
 		"trusty",
 		"utopic",
 		"vivid",
+		"wily",
+		"xenial",
+
 		"win10",
 		"win2008r2",
 		"win2012",
@@ -53,6 +55,5 @@ func (s *supportedSeriesWindowsSuite) TestSupportedSeries(c *gc.C) {
 		"win81",
 	}
 	series := series.SupportedSeries()
-	sort.Strings(series)
-	c.Assert(series, gc.DeepEquals, expectedSeries)
+	c.Assert(series, jc.SameContents, expectedSeries)
 }


### PR DESCRIPTION
For non ubuntu clients, wily and xenial need
to be added to the supported series list.

(Review request: http://reviews.vapour.ws/r/4347/)