### PR TITLE
1568312 - fail install after first "not found" err

### DIFF
--- a/packaging/manager/apt.go
+++ b/packaging/manager/apt.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/juju/errors"
 	"github.com/juju/utils/proxy"
 )
 
@@ -40,13 +41,13 @@ func (apt *apt) Search(pack string) (bool, error) {
 
 // Install is defined on the PackageManager interface.
 func (apt *apt) Install(packs ...string) error {
-	fatalErr := func(output string) bool {
+	fatalErr := func(output string) error {
 		// If we couldn't find the package don't retry.
 		// apt-get will report "Unable to locate package"
 		if strings.Contains(output, "Unable to locate package") {
-			return true
+			return errors.New("unable to locate package")
 		}
-		return false
+		return nil
 	}
 	_, _, err := RunCommandWithRetry(apt.cmder.InstallCmd(packs...), fatalErr)
 	return err

--- a/packaging/manager/apt.go
+++ b/packaging/manager/apt.go
@@ -25,7 +25,7 @@ type apt struct {
 
 // Search is defined on the PackageManager interface.
 func (apt *apt) Search(pack string) (bool, error) {
-	out, _, err := RunCommandWithRetry(apt.cmder.SearchCmd(pack))
+	out, _, err := RunCommandWithRetry(apt.cmder.SearchCmd(pack), nil)
 	if err != nil {
 		return false, err
 	}
@@ -36,6 +36,20 @@ func (apt *apt) Search(pack string) (bool, error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+// Install is defined on the PackageManager interface.
+func (apt *apt) Install(packs ...string) error {
+	fatalErr := func(output string) bool {
+		// If we couldn't find the package don't retry.
+		// apt-get will report "Unable to locate package"
+		if strings.Contains(output, "Unable to locate package") {
+			return true
+		}
+		return false
+	}
+	_, _, err := RunCommandWithRetry(apt.cmder.InstallCmd(packs...), fatalErr)
+	return err
 }
 
 // GetProxySettings is defined on the PackageManager interface.

--- a/packaging/manager/manager.go
+++ b/packaging/manager/manager.go
@@ -20,37 +20,37 @@ type basePackageManager struct {
 
 // InstallPrerequisite is defined on the PackageManager interface.
 func (pm *basePackageManager) InstallPrerequisite() error {
-	_, _, err := RunCommandWithRetry(pm.cmder.InstallPrerequisiteCmd())
+	_, _, err := RunCommandWithRetry(pm.cmder.InstallPrerequisiteCmd(), nil)
 	return err
 }
 
 // Update is defined on the PackageManager interface.
 func (pm *basePackageManager) Update() error {
-	_, _, err := RunCommandWithRetry(pm.cmder.UpdateCmd())
+	_, _, err := RunCommandWithRetry(pm.cmder.UpdateCmd(), nil)
 	return err
 }
 
 // Upgrade is defined on the PackageManager interface.
 func (pm *basePackageManager) Upgrade() error {
-	_, _, err := RunCommandWithRetry(pm.cmder.UpgradeCmd())
+	_, _, err := RunCommandWithRetry(pm.cmder.UpgradeCmd(), nil)
 	return err
 }
 
 // Install is defined on the PackageManager interface.
 func (pm *basePackageManager) Install(packs ...string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.InstallCmd(packs...))
+	_, _, err := RunCommandWithRetry(pm.cmder.InstallCmd(packs...), nil)
 	return err
 }
 
 // Remove is defined on the PackageManager interface.
 func (pm *basePackageManager) Remove(packs ...string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.RemoveCmd(packs...))
+	_, _, err := RunCommandWithRetry(pm.cmder.RemoveCmd(packs...), nil)
 	return err
 }
 
 // Purge is defined on the PackageManager interface.
 func (pm *basePackageManager) Purge(packs ...string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.PurgeCmd(packs...))
+	_, _, err := RunCommandWithRetry(pm.cmder.PurgeCmd(packs...), nil)
 	return err
 }
 
@@ -64,19 +64,19 @@ func (pm *basePackageManager) IsInstalled(pack string) bool {
 
 // AddRepository is defined on the PackageManager interface.
 func (pm *basePackageManager) AddRepository(repo string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.AddRepositoryCmd(repo))
+	_, _, err := RunCommandWithRetry(pm.cmder.AddRepositoryCmd(repo), nil)
 	return err
 }
 
 // RemoveRepository is defined on the PackageManager interface.
 func (pm *basePackageManager) RemoveRepository(repo string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.RemoveRepositoryCmd(repo))
+	_, _, err := RunCommandWithRetry(pm.cmder.RemoveRepositoryCmd(repo), nil)
 	return err
 }
 
 // Cleanup is defined on the PackageManager interface.
 func (pm *basePackageManager) Cleanup() error {
-	_, _, err := RunCommandWithRetry(pm.cmder.CleanupCmd())
+	_, _, err := RunCommandWithRetry(pm.cmder.CleanupCmd(), nil)
 	return err
 }
 

--- a/packaging/manager/manager_test.go
+++ b/packaging/manager/manager_test.go
@@ -81,8 +81,8 @@ var (
 // getMockRunCommandWithRetry returns a function with the same signature as
 // RunCommandWithRetry which saves the command it recieves in the provided
 // string whilst always returning no output, 0 error code and nil error.
-func getMockRunCommandWithRetry(stor *string) func(string, func(string) bool) (string, int, error) {
-	return func(cmd string, fatalErr func(string) bool) (string, int, error) {
+func getMockRunCommandWithRetry(stor *string) func(string, func(string) error) (string, int, error) {
+	return func(cmd string, fatalErr func(string) error) (string, int, error) {
 		*stor = cmd
 		return "", 0, nil
 	}

--- a/packaging/manager/manager_test.go
+++ b/packaging/manager/manager_test.go
@@ -81,8 +81,8 @@ var (
 // getMockRunCommandWithRetry returns a function with the same signature as
 // RunCommandWithRetry which saves the command it recieves in the provided
 // string whilst always returning no output, 0 error code and nil error.
-func getMockRunCommandWithRetry(stor *string) func(string) (string, int, error) {
-	return func(cmd string) (string, int, error) {
+func getMockRunCommandWithRetry(stor *string) func(string, func(string) bool) (string, int, error) {
+	return func(cmd string, fatalErr func(string) bool) (string, int, error) {
 		*stor = cmd
 		return "", 0, nil
 	}

--- a/packaging/manager/utils.go
+++ b/packaging/manager/utils.go
@@ -70,6 +70,15 @@ var RunCommandWithRetry = func(cmd string) (output string, code int, err error) 
 			return string(out), 0, nil
 		}
 
+		// If we couldn't find the package don't retry.
+		// apt-get will report "Unable to locate package"
+		// yum will report "Error: Nothing to do"
+		if strings.Contains(string(out), "Unable to locate package") ||
+			strings.Contains(string(out), "Error: Nothing to do") {
+			err = errors.Annotatef(err, "giving up; package not found")
+			break
+		}
+
 		exitError, ok := err.(*exec.ExitError)
 		if !ok {
 			err = errors.Annotatef(err, "unexpected error type %T", err)

--- a/packaging/manager/utils_test.go
+++ b/packaging/manager/utils_test.go
@@ -5,6 +5,7 @@
 package manager_test
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 
@@ -78,4 +79,48 @@ func (s *UtilsSuite) TestRunCommandWithRetryDoesNotCallCombinedOutputTwice(c *gc
 	err = yum.Install(testedPackageName)
 	c.Check(err, gc.ErrorMatches, "packaging command failed: exit status.*")
 	c.Check(calls, gc.Equals, minRetries)
+}
+
+func (s *UtilsSuite) TestRunCommandWithRetryStopsWithUnableToLocateErr(c *gc.C) {
+	const minRetries = 3
+	var calls int
+	state := os.ProcessState{}
+	cmdError := &exec.ExitError{&state}
+	s.PatchValue(&manager.AttemptStrategy, utils.AttemptStrategy{Min: minRetries})
+	s.PatchValue(&manager.ProcessStateSys, func(*os.ProcessState) interface{} {
+		return mockExitStatuser(100) // retry each time.
+	})
+	s.PatchValue(&manager.CommandOutput, func(cmd *exec.Cmd) ([]byte, error) {
+		calls++
+		cmdOutput := fmt.Sprintf("Reading state information...\nE: Unable to locate package %s",
+			testedPackageName)
+		return []byte(cmdOutput), cmdError
+	})
+
+	apt := manager.NewAptPackageManager()
+	err := apt.Install(testedPackageName)
+	c.Check(err, gc.ErrorMatches, "packaging command failed: giving up; package not found: exit status.*")
+	c.Check(calls, gc.Equals, 1)
+}
+
+func (s *UtilsSuite) TestRunCommandWithRetryStopsWithNothingToDoErr(c *gc.C) {
+	const minRetries = 3
+	var calls int
+	state := os.ProcessState{}
+	cmdError := &exec.ExitError{&state}
+	s.PatchValue(&manager.AttemptStrategy, utils.AttemptStrategy{Min: minRetries})
+	s.PatchValue(&manager.ProcessStateSys, func(*os.ProcessState) interface{} {
+		return mockExitStatuser(100) // retry each time.
+	})
+	s.PatchValue(&manager.CommandOutput, func(cmd *exec.Cmd) ([]byte, error) {
+		calls++
+		cmdOutput := fmt.Sprintf("No package %s available.\nError: Nothing to do",
+			testedPackageName)
+		return []byte(cmdOutput), cmdError
+	})
+
+	yum := manager.NewYumPackageManager()
+	err := yum.Install(testedPackageName)
+	c.Check(err, gc.ErrorMatches, "packaging command failed: giving up; package not found: exit status.*")
+	c.Check(calls, gc.Equals, 1)
 }

--- a/packaging/manager/utils_test.go
+++ b/packaging/manager/utils_test.go
@@ -81,7 +81,7 @@ func (s *UtilsSuite) TestRunCommandWithRetryDoesNotCallCombinedOutputTwice(c *gc
 	c.Check(calls, gc.Equals, minRetries)
 }
 
-func (s *UtilsSuite) TestRunCommandWithRetryStopsWithUnableToLocateErr(c *gc.C) {
+func (s *UtilsSuite) TestRunCommandWithRetryStopsWithFatalError(c *gc.C) {
 	const minRetries = 3
 	var calls int
 	state := os.ProcessState{}
@@ -93,34 +93,13 @@ func (s *UtilsSuite) TestRunCommandWithRetryStopsWithUnableToLocateErr(c *gc.C) 
 	s.PatchValue(&manager.CommandOutput, func(cmd *exec.Cmd) ([]byte, error) {
 		calls++
 		cmdOutput := fmt.Sprintf("Reading state information...\nE: Unable to locate package %s",
+
 			testedPackageName)
 		return []byte(cmdOutput), cmdError
 	})
 
 	apt := manager.NewAptPackageManager()
 	err := apt.Install(testedPackageName)
-	c.Check(err, gc.ErrorMatches, "packaging command failed: giving up; package not found: exit status.*")
-	c.Check(calls, gc.Equals, 1)
-}
-
-func (s *UtilsSuite) TestRunCommandWithRetryStopsWithNothingToDoErr(c *gc.C) {
-	const minRetries = 3
-	var calls int
-	state := os.ProcessState{}
-	cmdError := &exec.ExitError{&state}
-	s.PatchValue(&manager.AttemptStrategy, utils.AttemptStrategy{Min: minRetries})
-	s.PatchValue(&manager.ProcessStateSys, func(*os.ProcessState) interface{} {
-		return mockExitStatuser(100) // retry each time.
-	})
-	s.PatchValue(&manager.CommandOutput, func(cmd *exec.Cmd) ([]byte, error) {
-		calls++
-		cmdOutput := fmt.Sprintf("No package %s available.\nError: Nothing to do",
-			testedPackageName)
-		return []byte(cmdOutput), cmdError
-	})
-
-	yum := manager.NewYumPackageManager()
-	err := yum.Install(testedPackageName)
-	c.Check(err, gc.ErrorMatches, "packaging command failed: giving up; package not found: exit status.*")
+	c.Check(err, gc.ErrorMatches, "packaging command failed: encountered fatal error: exit status.*")
 	c.Check(calls, gc.Equals, 1)
 }

--- a/packaging/manager/utils_test.go
+++ b/packaging/manager/utils_test.go
@@ -100,6 +100,6 @@ func (s *UtilsSuite) TestRunCommandWithRetryStopsWithFatalError(c *gc.C) {
 
 	apt := manager.NewAptPackageManager()
 	err := apt.Install(testedPackageName)
-	c.Check(err, gc.ErrorMatches, "packaging command failed: encountered fatal error: exit status.*")
+	c.Check(err, gc.ErrorMatches, "packaging command failed: encountered fatal error: unable to locate package")
 	c.Check(calls, gc.Equals, 1)
 }

--- a/packaging/manager/yum.go
+++ b/packaging/manager/yum.go
@@ -19,7 +19,7 @@ type yum struct {
 
 // Search is defined on the PackageManager interface.
 func (yum *yum) Search(pack string) (bool, error) {
-	_, code, err := RunCommandWithRetry(yum.cmder.SearchCmd(pack))
+	_, code, err := RunCommandWithRetry(yum.cmder.SearchCmd(pack), nil)
 
 	// yum list package returns 1 when it cannot find the package.
 	if code == 1 {


### PR DESCRIPTION
We should stop trying to install packages if the
error indicates that the package could not be
found / does not exist.

Otherwise, we will spend an extra 5 minutes during
bootstrap waiting on a package that will never
install.

This 5 extra minutes causes Juju's CI tests to
timeout and is a bad user experience.

(Review request: http://reviews.vapour.ws/r/4502/)