### PR TITLE
corrected file URL generation on windows.

### DIFF
--- a/file_windows_test.go
+++ b/file_windows_test.go
@@ -23,16 +23,16 @@ func (s *windowsFileSuite) TestMakeFileURL(c *gc.C) {
 		expected string
 	}{{
 		in:       "file://C:\\foo\\baz",
-		expected: "file://\\\\localhost\\C$/foo/baz",
+		expected: "file://C:/foo/baz",
 	}, {
 		in:       "C:\\foo\\baz",
-		expected: "file://\\\\localhost\\C$/foo/baz",
+		expected: "file://C:/foo/baz",
 	}, {
 		in:       "http://foo/baz",
 		expected: "http://foo/baz",
 	}, {
-		in:       "file://\\\\localhost\\C$/foo/baz",
-		expected: "file://\\\\localhost\\C$/foo/baz",
+		in:       "file://C:/foo/baz",
+		expected: "file://C:/foo/baz",
 	}}
 
 	for i, t := range makeFileURLTests {

--- a/packaging/manager/manager_test.go
+++ b/packaging/manager/manager_test.go
@@ -268,7 +268,7 @@ func (s *ManagerSuite) TestSimpleErrorCases(c *gc.C) {
 		expectedErrMsg = `E: I done failed :(`
 	)
 	state := os.ProcessState{}
-	cmdError := &exec.ExitError{&state}
+	cmdError := &exec.ExitError{ProcessState: &state}
 
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte(expectedErrMsg), error(cmdError))
 

--- a/packaging/manager/utils_test.go
+++ b/packaging/manager/utils_test.go
@@ -47,7 +47,7 @@ func (s *UtilsSuite) TestRunCommandWithRetryDoesNotCallCombinedOutputTwice(c *gc
 	const minRetries = 3
 	var calls int
 	state := os.ProcessState{}
-	cmdError := &exec.ExitError{&state}
+	cmdError := &exec.ExitError{ProcessState: &state}
 	s.PatchValue(&manager.AttemptStrategy, utils.AttemptStrategy{Min: minRetries})
 	s.PatchValue(&manager.ProcessStateSys, func(*os.ProcessState) interface{} {
 		return mockExitStatuser(100) // retry each time.
@@ -85,7 +85,7 @@ func (s *UtilsSuite) TestRunCommandWithRetryStopsWithFatalError(c *gc.C) {
 	const minRetries = 3
 	var calls int
 	state := os.ProcessState{}
-	cmdError := &exec.ExitError{&state}
+	cmdError := &exec.ExitError{ProcessState: &state}
 	s.PatchValue(&manager.AttemptStrategy, utils.AttemptStrategy{Min: minRetries})
 	s.PatchValue(&manager.ProcessStateSys, func(*os.ProcessState) interface{} {
 		return mockExitStatuser(100) // retry each time.


### PR DESCRIPTION
File URL was generating using file://\\localhost\\<drive>$/path/to/file which no longer works in go 1.6 HTTP client.
The new URL looks like file://<drive>:/path/to/file

(Review request: http://reviews.vapour.ws/r/4662/)