### PR TITLE
add SecureTLSConfig function

### DIFF
--- a/tls_transport_go13.go
+++ b/tls_transport_go13.go
@@ -27,3 +27,34 @@ func NewHttpTLSTransport(tlsConfig *tls.Config) *http.Transport {
 	registerFileProtocol(transport)
 	return transport
 }
+
+// knownGoodCipherSuites contains the list of secure cipher suites to use
+// with tls.Config.  This list currently differs from the list in crypto/tls by
+// excluding all RC4 implementations, due to known security vulnerabilities in
+// RC4 - CVE-2013-2566, CVE-2015-2808.  We also exclude ciphersuites which do
+// not provide forward secrecy.
+var knownGoodCipherSuites = []uint16{
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+}
+
+// SecureTLSConfig returns a tls.Config that conforms to Juju's security
+// standards, so as to avoid known security vulnerabilities in certain
+// configurations.
+//
+// Currently it excludes RC4 implementations from the available ciphersuites,
+// requires ciphersuites that provide forward secrecy, and sets the minimum TLS
+// version to 1.2.
+func SecureTLSConfig() *tls.Config {
+	return &tls.Config{
+		CipherSuites: knownGoodCipherSuites,
+		MinVersion:   tls.VersionTLS12,
+	}
+}


### PR DESCRIPTION
This is a helper function for use in juju that returns a tls.Config that is secure against known cryptographic vulnerabilities and ensures Juju is always using the most secure connections possible.

Verified with Security teams and the web teams that this configuration is workable with known clients and secure.