### PR TITLE
ssh: Allow StrictHostKeyChecking to be configured

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -36,6 +36,9 @@ type Options struct {
 	// knownHostsFile is a path to a file in which to save the host's
 	// fingerprint.
 	knownHostsFile string
+	// strictHostKeyChecking sets that the host being connected to must
+	// exist in the known_hosts file, and with a matching public key.
+	strictHostKeyChecking bool
 }
 
 // SetProxyCommand sets a command to execute to proxy traffic through.
@@ -61,6 +64,13 @@ func (o *Options) EnablePTY() {
 // Host fingerprints are saved in ~/.ssh/known_hosts by default.
 func (o *Options) SetKnownHostsFile(file string) {
 	o.knownHostsFile = file
+}
+
+// EnableStrictHostKeyChecking requires that the host being connected
+// to must exist in the known_hosts file, and with a matching public
+// key.
+func (o *Options) EnableStrictHostKeyChecking() {
+	o.strictHostKeyChecking = true
 }
 
 // AllowPasswordAuthentication allows the SSH

--- a/ssh/ssh_openssh.go
+++ b/ssh/ssh_openssh.go
@@ -15,8 +15,6 @@ import (
 	"github.com/juju/utils"
 )
 
-var opensshCommonOptions = []string{"-o", "StrictHostKeyChecking no"}
-
 // default identities will not be attempted if
 // -i is specified and they are not explcitly
 // included.
@@ -65,10 +63,12 @@ func NewOpenSSHClient() (*OpenSSHClient, error) {
 }
 
 func opensshOptions(options *Options, commandKind opensshCommandKind) []string {
-	args := append([]string{}, opensshCommonOptions...)
 	if options == nil {
 		options = &Options{}
 	}
+	var args []string
+
+	args = append(args, "-o", "StrictHostKeyChecking "+yesNo(options.strictHostKeyChecking))
 	if len(options.proxyCommand) > 0 {
 		args = append(args, "-o", "ProxyCommand "+utils.CommandString(options.proxyCommand...))
 	}
@@ -194,4 +194,11 @@ func (c *opensshCmd) Kill() error {
 		return errors.Errorf("process has not been started")
 	}
 	return c.Process.Kill()
+}
+
+func yesNo(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
 }

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -122,6 +122,15 @@ func (s *SSHCommandSuite) TestCommandSetKnownHostsFile(c *gc.C) {
 	)
 }
 
+func (s *SSHCommandSuite) TestCommandStrictHostKeyChecking(c *gc.C) {
+	var opts ssh.Options
+	opts.EnableStrictHostKeyChecking()
+	s.assertCommandArgs(c, s.commandOptions([]string{echoCommand, "123"}, &opts),
+		fmt.Sprintf("%s -o StrictHostKeyChecking yes -o PasswordAuthentication no -o ServerAliveInterval 30 localhost %s 123",
+			s.fakessh, echoCommand),
+	)
+}
+
 func (s *SSHCommandSuite) TestCommandAllowPasswordAuthentication(c *gc.C) {
 	var opts ssh.Options
 	opts.AllowPasswordAuthentication()


### PR DESCRIPTION
Previously this option was forced to "no" but it needs to be configurable to support upcoming changes to Juju.

(Review request: http://reviews.vapour.ws/r/4738/)