### PR TITLE
ssh: Add Option.SetStrictHostKeyChecking()

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -18,6 +18,31 @@ import (
 	je "github.com/juju/errors"
 )
 
+// StrictHostChecksOption defines the possible values taken by
+// Option.SetStrictHostKeyChecking().
+type StrictHostChecksOption int
+
+const (
+	// StrictHostChecksNo disables strict host key checking. This is
+	// the default.
+	StrictHostChecksNo StrictHostChecksOption = iota
+
+	// StrictHostChecksYes enabled strict host key checking
+	// enabled. Target hosts must appear in known_hosts file or
+	// connections will fail.
+	StrictHostChecksYes
+
+	// StrictHostChecksAsk will cause openssh to ask the user about
+	// hosts that don't appear in known_hosts file.
+	StrictHostChecksAsk
+
+	// StrictHostChecksUnset will prevent the addition of a
+	// StrictHostKeyChecking option to the openssh command line. The
+	// StrictHostKeyChecking setting from user's personal
+	// configuration will be used.
+	StrictHostChecksUnset
+)
+
 // Options is a client-implementation independent SSH options set.
 type Options struct {
 	// proxyCommand specifies the command to
@@ -36,9 +61,10 @@ type Options struct {
 	// knownHostsFile is a path to a file in which to save the host's
 	// fingerprint.
 	knownHostsFile string
+
 	// strictHostKeyChecking sets that the host being connected to must
 	// exist in the known_hosts file, and with a matching public key.
-	strictHostKeyChecking bool
+	strictHostKeyChecking StrictHostChecksOption
 }
 
 // SetProxyCommand sets a command to execute to proxy traffic through.
@@ -68,9 +94,16 @@ func (o *Options) SetKnownHostsFile(file string) {
 
 // EnableStrictHostKeyChecking requires that the host being connected
 // to must exist in the known_hosts file, and with a matching public
-// key.
+// key. See also SetStrictHostKeyChecking.
 func (o *Options) EnableStrictHostKeyChecking() {
-	o.strictHostKeyChecking = true
+	o.strictHostKeyChecking = StrictHostChecksYes
+}
+
+// SetStrictHostKeyChecking sets the desired host key checking
+// behaviour. It takes one of the StrictHostChecksOption constants.
+// See also EnableStrictHostKeyChecking.
+func (o *Options) SetStrictHostKeyChecking(value StrictHostChecksOption) {
+	o.strictHostKeyChecking = value
 }
 
 // AllowPasswordAuthentication allows the SSH

--- a/ssh/ssh_openssh.go
+++ b/ssh/ssh_openssh.go
@@ -68,10 +68,26 @@ func opensshOptions(options *Options, commandKind opensshCommandKind) []string {
 	}
 	var args []string
 
-	args = append(args, "-o", "StrictHostKeyChecking "+yesNo(options.strictHostKeyChecking))
+	var hostChecks string
+	switch options.strictHostKeyChecking {
+	case StrictHostChecksYes:
+		hostChecks = "yes"
+	case StrictHostChecksNo:
+		hostChecks = "no"
+	case StrictHostChecksAsk:
+		hostChecks = "ask"
+	default:
+		// StrictHostChecksUnset and invalid values are handled the
+		// same way (the option doesn't get included).
+	}
+	if hostChecks != "" {
+		args = append(args, "-o", "StrictHostKeyChecking "+hostChecks)
+	}
+
 	if len(options.proxyCommand) > 0 {
 		args = append(args, "-o", "ProxyCommand "+utils.CommandString(options.proxyCommand...))
 	}
+
 	if !options.passwordAuthAllowed {
 		args = append(args, "-o", "PasswordAuthentication no")
 	}
@@ -194,11 +210,4 @@ func (c *opensshCmd) Kill() error {
 		return errors.Errorf("process has not been started")
 	}
 	return c.Process.Kill()
-}
-
-func yesNo(v bool) string {
-	if v {
-		return "yes"
-	}
-	return "no"
 }

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -131,6 +131,32 @@ func (s *SSHCommandSuite) TestCommandStrictHostKeyChecking(c *gc.C) {
 	)
 }
 
+func (s *SSHCommandSuite) TestSetStrictHostKeyChecking(c *gc.C) {
+	commandPattern := fmt.Sprintf("%s%%s -o PasswordAuthentication no -o ServerAliveInterval 30 localhost %s 123",
+		s.fakessh, echoCommand)
+
+	tests := []struct {
+		input    ssh.StrictHostChecksOption
+		expected string
+	}{
+		{ssh.StrictHostChecksNo, "no"},
+		{ssh.StrictHostChecksYes, "yes"},
+		{ssh.StrictHostChecksAsk, "ask"},
+		{ssh.StrictHostChecksUnset, ""},
+		{ssh.StrictHostChecksOption(999), ""},
+	}
+	for _, t := range tests {
+		var opts ssh.Options
+		opts.SetStrictHostKeyChecking(t.input)
+		expectedOpt := ""
+		if t.expected != "" {
+			expectedOpt = " -o StrictHostKeyChecking " + t.expected
+		}
+		s.assertCommandArgs(c, s.commandOptions([]string{echoCommand, "123"}, &opts),
+			fmt.Sprintf(commandPattern, expectedOpt))
+	}
+}
+
 func (s *SSHCommandSuite) TestCommandAllowPasswordAuthentication(c *gc.C) {
 	var opts ssh.Options
 	opts.AllowPasswordAuthentication()


### PR DESCRIPTION
This change adds Support for all the openssh StrictHostKeyChecking values, instead of just "yes" or "no". In order to preserve compatibility with the pre-existing behaviour, the default value is "no".

This is needed for work being done to juju ssh/scp/debughooks where sometimes the option needs to be unset.



(Review request: http://reviews.vapour.ws/r/4794/)