### PR TITLE
tls_transport: The build tag needs to be 1.5 for the contents of this file

### DIFF
--- a/tls_transport_go15.go
+++ b/tls_transport_go15.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
-// +build go1.3
+// +build go1.5
 
 package utils
 


### PR DESCRIPTION
The file contains two values:
```
tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
```
which only came in in go1.5
(Review request: http://reviews.vapour.ws/r/4806/)