### PR TITLE
fslock: unexport lock.isLockHeld

### DIFF
--- a/fslock/export_test.go
+++ b/fslock/export_test.go
@@ -9,10 +9,4 @@ func IsAlive(lock *Lock, PID int) bool {
 	return lock.isAlive(PID)
 }
 
-func DeclareDead(lock *Lock) {
-	lock.declareDead()
-}
-
-func AliveFile(lock *Lock) string {
-	return lock.aliveFile(lock.PID)
-}
+func (l *Lock) IsLockHeld() bool { return l.isLockHeld() }

--- a/fslock/fslock.go
+++ b/fslock/fslock.go
@@ -199,7 +199,7 @@ func (lock *Lock) clean() error {
 	// If a lock exists, see if it is stale
 	lockInfo, err := lock.readLock()
 	if err != nil {
-		return nil
+		return err
 	}
 
 	if lock.isAlive(lockInfo.PID) {
@@ -331,8 +331,8 @@ func (lock *Lock) readLock() (lockInfo onDisk, err error) {
 	return lockInfo, err
 }
 
-// IsLockHeld returns whether the lock is currently held by the receiver.
-func (lock *Lock) IsLockHeld() bool {
+// isLockHeld returns whether the lock is currently held by the receiver.
+func (lock *Lock) isLockHeld() bool {
 	lockInfo, err := lock.readLock()
 	if err != nil {
 		return false
@@ -343,7 +343,7 @@ func (lock *Lock) IsLockHeld() bool {
 // Unlock releases a held lock.  If the lock is not held ErrLockNotHeld is
 // returned.
 func (lock *Lock) Unlock() error {
-	if !lock.IsLockHeld() {
+	if !lock.isLockHeld() {
 		return ErrLockNotHeld
 	}
 	// To ensure reasonable unlocking, we should rename to a temp name, and delete that.


### PR DESCRIPTION
Unexport isLockHeld, it is unused in juju and cannot be used safely as
any value reported by this function is stale.

(Review request: http://reviews.vapour.ws/r/4886/)