### PR TITLE
Extract natural sorting helpers & make more generic

### DIFF
--- a/naturalsort.go
+++ b/naturalsort.go
@@ -1,0 +1,57 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// SortStringsNaturally sorts strings according to their natural sort order.
+func SortStringsNaturally(s []string) []string {
+	sort.Sort(naturally(s))
+	return s
+}
+
+type naturally []string
+
+func (n naturally) Len() int {
+	return len(n)
+}
+
+func (n naturally) Swap(a, b int) {
+	n[a], n[b] = n[b], n[a]
+}
+
+// Less sorts by non-numeric prefix and numeric suffix
+// when one exists.
+func (n naturally) Less(a, b int) bool {
+	aPrefix, aNumber := splitAtNumber(n[a])
+	bPrefix, bNumber := splitAtNumber(n[b])
+	if aPrefix == bPrefix {
+		return aNumber < bNumber
+	}
+	return n[a] < n[b]
+}
+
+// splitAtNumber splits given string into prefix and numeric suffix.
+// If no numeric suffix exists, full original string is returned as
+// prefix with -1 as a suffix.
+func splitAtNumber(str string) (string, int) {
+	i := strings.LastIndexFunc(str, func(r rune) bool {
+		return !unicode.IsDigit(r)
+	}) + 1
+	if i == len(str) {
+		// no numeric suffix
+		return str, -1
+	}
+	n, err := strconv.Atoi(str[i:])
+	if err != nil {
+		panic(fmt.Sprintf("parsing number %v: %v", str[i:], err)) // should never happen
+	}
+	return str[:i], n
+}

--- a/naturalsort_test.go
+++ b/naturalsort_test.go
@@ -1,0 +1,113 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"sort"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+)
+
+type naturalSortSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&naturalSortSuite{})
+
+func (s *naturalSortSuite) TestNaturallyEmpty(c *gc.C) {
+	s.assertNaturallySort(
+		c,
+		[]string{},
+		[]string{},
+	)
+}
+
+func (s *naturalSortSuite) TestNaturallyAlpha(c *gc.C) {
+	s.assertNaturallySort(
+		c,
+		[]string{"bac", "cba", "abc"},
+		[]string{"abc", "bac", "cba"},
+	)
+}
+
+func (s *naturalSortSuite) TestNaturallyAlphaNumeric(c *gc.C) {
+	s.assertNaturallySort(
+		c,
+		[]string{"a1", "a10", "a100", "a11"},
+		[]string{"a1", "a10", "a11", "a100"},
+	)
+}
+
+func (s *naturalSortSuite) TestNaturallySpecial(c *gc.C) {
+	s.assertNaturallySort(
+		c,
+		[]string{"a1", "a10", "a100", "a1/1", "1a"},
+		[]string{"1a", "a1", "a1/1", "a10", "a100"},
+	)
+}
+
+func (s *naturalSortSuite) TestNaturallyTagLike(c *gc.C) {
+	s.assertNaturallySort(
+		c,
+		[]string{"a1/1", "a1/11", "a1/2", "a1/7", "a1/100"},
+		[]string{"a1/1", "a1/2", "a1/7", "a1/11", "a1/100"},
+	)
+}
+
+func (s *naturalSortSuite) TestNaturallySeveralNumericParts(c *gc.C) {
+	s.assertNaturallySort(
+		c,
+		[]string{"x2-y08", "x2-g8", "x8-y8", "x2-y7"},
+		[]string{"x2-g8", "x2-y7", "x2-y08", "x8-y8"},
+	)
+}
+
+func (s *naturalSortSuite) TestNaturallyFoo(c *gc.C) {
+	s.assertNaturallySort(
+		c,
+		[]string{"foo2", "foo01"},
+		[]string{"foo01", "foo2"},
+	)
+}
+
+func (s *naturalSortSuite) TestNaturallyIPs(c *gc.C) {
+	s.assertNaturallySort(
+		c,
+		[]string{"100.001.010.123", "001.001.010.123", "001.002.010.123"},
+		[]string{"001.001.010.123", "001.002.010.123", "100.001.010.123"},
+	)
+}
+
+func (s *naturalSortSuite) TestNaturallyJuju(c *gc.C) {
+	s.assertNaturallySort(
+		c,
+		[]string{
+			"ubuntu/0",
+			"ubuntu/1",
+			"ubuntu/10",
+			"ubuntu/100",
+			"ubuntu/101",
+			"ubuntu/102",
+			"ubuntu/103",
+			"ubuntu/104",
+			"ubuntu/11"},
+		[]string{
+			"ubuntu/0",
+			"ubuntu/1",
+			"ubuntu/10",
+			"ubuntu/11",
+			"ubuntu/100",
+			"ubuntu/101",
+			"ubuntu/102",
+			"ubuntu/103",
+			"ubuntu/104"},
+	)
+}
+
+func (s *naturalSortSuite) assertNaturallySort(c *gc.C, sample, expected []string) {
+	sort.Sort(naturally(sample))
+	c.Assert(sample, gc.DeepEquals, expected)
+}

--- a/naturalsort_test.go
+++ b/naturalsort_test.go
@@ -1,113 +1,147 @@
-// Copyright 2015 Canonical Ltd.
+// Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package common
+package utils_test
 
 import (
-	"sort"
+	"math/rand"
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/testing"
+	"github.com/juju/utils"
 )
 
 type naturalSortSuite struct {
-	testing.BaseSuite
+	testing.IsolationSuite
 }
 
 var _ = gc.Suite(&naturalSortSuite{})
 
-func (s *naturalSortSuite) TestNaturallyEmpty(c *gc.C) {
-	s.assertNaturallySort(
-		c,
-		[]string{},
-		[]string{},
-	)
+func (s *naturalSortSuite) TestEmpty(c *gc.C) {
+	checkCorrectSort(c, []string{})
 }
 
-func (s *naturalSortSuite) TestNaturallyAlpha(c *gc.C) {
-	s.assertNaturallySort(
-		c,
-		[]string{"bac", "cba", "abc"},
-		[]string{"abc", "bac", "cba"},
-	)
+func (s *naturalSortSuite) TestAlpha(c *gc.C) {
+	checkCorrectSort(c, []string{"abc", "bac", "cba"})
 }
 
-func (s *naturalSortSuite) TestNaturallyAlphaNumeric(c *gc.C) {
-	s.assertNaturallySort(
-		c,
-		[]string{"a1", "a10", "a100", "a11"},
-		[]string{"a1", "a10", "a11", "a100"},
-	)
+func (s *naturalSortSuite) TestNumVsString(c *gc.C) {
+	checkCorrectSort(c, []string{"1", "a"})
 }
 
-func (s *naturalSortSuite) TestNaturallySpecial(c *gc.C) {
-	s.assertNaturallySort(
-		c,
-		[]string{"a1", "a10", "a100", "a1/1", "1a"},
-		[]string{"1a", "a1", "a1/1", "a10", "a100"},
-	)
+func (s *naturalSortSuite) TestStringVsStringNum(c *gc.C) {
+	checkCorrectSort(c, []string{"a", "a1"})
 }
 
-func (s *naturalSortSuite) TestNaturallyTagLike(c *gc.C) {
-	s.assertNaturallySort(
-		c,
-		[]string{"a1/1", "a1/11", "a1/2", "a1/7", "a1/100"},
-		[]string{"a1/1", "a1/2", "a1/7", "a1/11", "a1/100"},
-	)
+func (s *naturalSortSuite) TestCommonPrefix(c *gc.C) {
+	checkCorrectSort(c, []string{"a1", "a1a", "a1b", "a2b", "a2c"})
 }
 
-func (s *naturalSortSuite) TestNaturallySeveralNumericParts(c *gc.C) {
-	s.assertNaturallySort(
-		c,
-		[]string{"x2-y08", "x2-g8", "x8-y8", "x2-y7"},
-		[]string{"x2-g8", "x2-y7", "x2-y08", "x8-y8"},
-	)
+func (s *naturalSortSuite) TestDifferentNumberLengths(c *gc.C) {
+	checkCorrectSort(c, []string{"a1a", "a2", "a22a", "a333", "a333a", "a333b"})
 }
 
-func (s *naturalSortSuite) TestNaturallyFoo(c *gc.C) {
-	s.assertNaturallySort(
-		c,
-		[]string{"foo2", "foo01"},
-		[]string{"foo01", "foo2"},
-	)
+func (s *naturalSortSuite) TestZeroPadding(c *gc.C) {
+	checkCorrectSort(c, []string{"a1", "a002", "a3"})
 }
 
-func (s *naturalSortSuite) TestNaturallyIPs(c *gc.C) {
-	s.assertNaturallySort(
-		c,
-		[]string{"100.001.010.123", "001.001.010.123", "001.002.010.123"},
-		[]string{"001.001.010.123", "001.002.010.123", "100.001.010.123"},
-	)
+func (s *naturalSortSuite) TestMixed(c *gc.C) {
+	checkCorrectSort(c, []string{"1a", "a1", "a1/1", "a10", "a100"})
 }
 
-func (s *naturalSortSuite) TestNaturallyJuju(c *gc.C) {
-	s.assertNaturallySort(
-		c,
-		[]string{
-			"ubuntu/0",
-			"ubuntu/1",
-			"ubuntu/10",
-			"ubuntu/100",
-			"ubuntu/101",
-			"ubuntu/102",
-			"ubuntu/103",
-			"ubuntu/104",
-			"ubuntu/11"},
-		[]string{
-			"ubuntu/0",
-			"ubuntu/1",
-			"ubuntu/10",
-			"ubuntu/11",
-			"ubuntu/100",
-			"ubuntu/101",
-			"ubuntu/102",
-			"ubuntu/103",
-			"ubuntu/104"},
-	)
+func (s *naturalSortSuite) TestSeveralNumericParts(c *gc.C) {
+	checkCorrectSort(c, []string{
+		"x",
+		"x1",
+		"x1-g0",
+		"x1-g1",
+		"x1-g2",
+		"x1-g10",
+		"x2",
+		"x2-g0",
+		"x2-g2",
+		"x11-g0",
+		"x11-g0-0",
+		"x11-g0-1",
+		"x11-g0-10",
+		"x11-g0-11",
+		"x11-g0-20",
+		"x11-g0-100",
+		"x11-g10-1",
+		"x11-g10-10",
+		"xx1",
+		"xx10",
+	})
 }
 
-func (s *naturalSortSuite) assertNaturallySort(c *gc.C, sample, expected []string) {
-	sort.Sort(naturally(sample))
-	c.Assert(sample, gc.DeepEquals, expected)
+func (s *naturalSortSuite) TestUnitNameLike(c *gc.C) {
+	checkCorrectSort(c, []string{"a1/1", "a1/2", "a1/7", "a1/11", "a1/100"})
+}
+
+func (s *naturalSortSuite) TestMachineIdLike(c *gc.C) {
+	checkCorrectSort(c, []string{
+		"1",
+		"1/lxc/0",
+		"1/lxc/1",
+		"1/lxc/2",
+		"1/lxc/10",
+		"1/lxd/0",
+		"1/lxd/1",
+		"1/lxd/10",
+		"2",
+		"11",
+		"11/lxc/6",
+		"11/lxc/60",
+		"20",
+		"21",
+	})
+}
+
+func (s *naturalSortSuite) TestIPs(c *gc.C) {
+	checkCorrectSort(c, []string{
+		"1.1.10.122",
+		"001.001.010.123",
+		"001.002.010.123",
+		"100.001.010.123",
+		"100.1.10.124",
+		"100.2.10.124",
+	})
+}
+
+func checkCorrectSort(c *gc.C, expected []string) {
+	checkSort(c, expected, reverse)
+	for i := 0; i < 5; i++ {
+		checkSort(c, expected, shuffle)
+	}
+}
+
+func checkSort(c *gc.C, expected []string, xform func([]string)) {
+	input := copyStrSlice(expected)
+	xform(input)
+	origInput := copyStrSlice(input)
+	utils.SortStringsNaturally(input)
+	c.Check(input, gc.DeepEquals, expected, gc.Commentf("input was: %#v", origInput))
+}
+
+func copyStrSlice(in []string) []string {
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}
+
+func shuffle(a []string) {
+	// See https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#Modern_method
+	for i := len(a) - 1; i >= 1; i-- {
+		j := rand.Intn(i + 1)
+		a[i], a[j] = a[j], a[i]
+	}
+}
+
+func reverse(a []string) {
+	size := len(a)
+	for i := 0; i < size/2; i++ {
+		j := size - i - 1
+		a[i], a[j] = a[j], a[i]
+	}
 }


### PR DESCRIPTION
The sorting implementation which sorts strings with integer suffixes "naturally" has been extracted from github.com/juju/juju/cmd/juju/common. 

The implementation as been made generic so that it supports multiple runs of digits. In Juju's case this means that machine ids for containers are correctly sorted, as are unit names which contain digits before the unit number.

Testing of the algorithm has been simplified. Instead of having to provide an input and the desired output, only the desired output needs to be provided. The test infrastructure will test the algorithm by sorting a reverse of the input as well as a randomly shuffled version of the input. This makes writing test cases much easier.

Test cases have also been made more orthogonal. The unnecessarily long test names have also been cleaned up.

(Review request: http://reviews.vapour.ws/r/5108/)