### PR TITLE
Don't use insecure ciphers.

### DIFF
--- a/tls_transport_go13.go
+++ b/tls_transport_go13.go
@@ -29,20 +29,23 @@ func NewHttpTLSTransport(tlsConfig *tls.Config) *http.Transport {
 }
 
 // knownGoodCipherSuites contains the list of secure cipher suites to use
-// with tls.Config.  This list currently differs from the list in crypto/tls by
-// excluding all RC4 implementations, due to known security vulnerabilities in
-// RC4 - CVE-2013-2566, CVE-2015-2808.  We also exclude ciphersuites which do
-// not provide forward secrecy.
+// with tls.Config. This list matches those that Go 1.6 implements from
+// https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations.
+//
+// https://tools.ietf.org/html/rfc7525#section-4.2 excludes RSA exchange completely
+// so we could be more strict if all our clients will support
+// TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256/384. Unfortunately Go's crypto library
+// is limited and doesn't support DHE-RSA-AES256-GCM-SHA384 and
+// DHE-RSA-AES256-SHA256, which are part of the recommended set.
+//
+// Unfortunately we can't drop the RSA algorithms because our servers aren't
+// generating ECDHE keys.
 var knownGoodCipherSuites = []uint16{
-	tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-	tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-	tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
-	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 }
 
 // SecureTLSConfig returns a tls.Config that conforms to Juju's security


### PR DESCRIPTION
Initially this was about removing 3DES because it is very slow (at least the Go 1.6 implementation), but on closer inspection knownGoodCipherSuites didn't actually know what a good cipher suite was and this has been fixed.

It would have been nice to move to the ciphers listed at https://tools.ietf.org/html/rfc7525#section-4.2 but Go doesn't support them all. The ones it does support are TLS_ECDHE_ECDSA_WITH_AES_* and we aren't generating server side certificates for them. Because of that TLS_ECDHE_RSA_WITH_AES_256_* have been kept, which is in line with https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations.

Even if we don't accept this change we should change our algorithm for negotiating a cipher to use because we were ending up with the worst that both client and server would support. https://tools.ietf.org/html/rfc7525#section-4.2.1 says:
```
   Clients SHOULD include TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 as the
   first proposal to any server, unless they have prior knowledge that
   the server cannot respond to a TLS 1.2 client_hello message.

   Servers MUST prefer this cipher suite over weaker cipher suites
   whenever it is proposed, even if it is not the first proposal.

   Clients are of course free to offer stronger cipher suites, e.g.,
   using AES-256; when they do, the server SHOULD prefer the stronger
   cipher suite unless there are compelling reasons (e.g., seriously
   degraded performance) to choose otherwise.
```
I think it is clear that we don't do any of this.

(Review request: http://reviews.vapour.ws/r/5213/)