### PR TITLE
update juju/cmd dependency to reflect the gofmt revision

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,4 +1,4 @@
-github.com/juju/cmd	git	ff12e27343f854a8bf3efeb9f3467c868134e7af	2016-08-09T20:49:20Z
+github.com/juju/cmd	git	7c57a7d5a20602e4563a83f2d530283ca0e6f481	2016-08-10T12:53:08Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T17:52:03Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z


### PR DESCRIPTION
Per approval from #230 , this merely updates the dependency to select the gofmt'ed version of the change to juju/cmd.