### PR TITLE
Revert "Merge pull request #203 from bogdanteleaga/exec-fixes"

### DIFF
--- a/exec/exec_linux_test.go
+++ b/exec/exec_linux_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/juju/utils/exec"
 )
 
+// 0 is thrown by linux because RunParams.Wait
+// only sets the code if the process exits cleanly
+const cancelErrCode = 0
+
 func (*execSuite) TestRunCommands(c *gc.C) {
 	newDir := c.MkDir()
 

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -38,7 +38,9 @@ func (*execSuite) TestWaitWithCancel(c *gc.C) {
 	cancelChan <- struct{}{}
 	result, err := params.WaitWithCancel(cancelChan)
 	c.Assert(err, gc.Equals, exec.ErrCancelled)
-	c.Assert(result, gc.IsNil)
+	c.Assert(string(result.Stdout), gc.Equals, "")
+	c.Assert(string(result.Stderr), gc.Equals, "")
+	c.Assert(result.Code, gc.Equals, cancelErrCode)
 }
 
 func (s *execSuite) TestKillAbortedIfUnsuccessfull(c *gc.C) {

--- a/exec/exec_windows_test.go
+++ b/exec/exec_windows_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/juju/utils/exec"
 )
 
+// 1 is thrown by powershell after the a command is cancelled
+const cancelErrCode = 1
+
 // longPath is copied over from the symlink package. This should be removed
 // if we add it to gc or in some other convenience package
 func longPath(path string) ([]uint16, error) {


### PR DESCRIPTION
This reverts commit 8a9dea08709bd9f65bbf7ed2c9bcfa0656eb8a7b, reversing
changes made to 10adcbfe55417518543ed3c3341de2c7db0a3450.

This causes an error in juju/juju, specifically uniter. See http://paste.ubuntu.com/22965595/.