### PR TITLE
make outgoing address checker work under Go 1.7

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -10,11 +10,11 @@ import (
 var (
 	GOMAXPROCS        = &gomaxprocs
 	NumCPU            = &numCPU
-	Dial              = dial
-	NetDial           = &netDial
 	ResolveSudoByFunc = resolveSudo
 )
 
 func ExposeBackoffTimerDuration(bot *BackoffTimer) time.Duration {
 	return bot.currentDuration
 }
+
+var IsLocalAddr = isLocalAddr

--- a/http-1_4.go
+++ b/http-1_4.go
@@ -1,0 +1,21 @@
+//+build !go1.7
+
+package utils
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+)
+
+// installHTTPDialShim patches the default HTTP transport so
+// that it fails when an attempt is made to dial a non-local
+// host.
+func installHTTPDialShim(t *http.Transport) {
+	t.Dial = func(network, addr string) (net.Conn, error) {
+		if !OutgoingAccessAllowed && !isLocalAddr(addr) {
+			return nil, fmt.Errorf("access to address %q not allowed", addr)
+		}
+		return net.Dial(network, addr)
+	}
+}

--- a/http-1_7.go
+++ b/http-1_7.go
@@ -1,0 +1,32 @@
+//+build go1.7
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+var ctxtDialer = &net.Dialer{
+	Timeout:   30 * time.Second,
+	KeepAlive: 30 * time.Second,
+}
+
+// installHTTPDialShim patches the default HTTP transport so
+// that it fails when an attempt is made to dial a non-local
+// host.
+//
+// Note that this is Go version dependent because in Go 1.7 and above,
+// the DialContext field was introduced (and set in http.DefaultTransport)
+// which overrides the Dial field.
+func installHTTPDialShim(t *http.Transport) {
+	t.DialContext = func(ctxt context.Context, network, addr string) (net.Conn, error) {
+		if !OutgoingAccessAllowed && !isLocalAddr(addr) {
+			return nil, fmt.Errorf("access to address %q not allowed", addr)
+		}
+		return ctxtDialer.DialContext(ctxt, network, addr)
+	}
+}

--- a/http.go
+++ b/http.go
@@ -22,7 +22,7 @@ func init() {
 	// hit the above Go bug.
 	defaultTransport := http.DefaultTransport.(*http.Transport)
 	defaultTransport.DisableKeepAlives = true
-	defaultTransport.Dial = dial
+	installHTTPDialShim(defaultTransport)
 	registerFileProtocol(defaultTransport)
 }
 
@@ -112,21 +112,10 @@ func ParseBasicAuthHeader(h http.Header) (userid, password string, err error) {
 // localhost can be dialled.
 var OutgoingAccessAllowed = true
 
-// Override for tests.
-var netDial = net.Dial
-
-func dial(network, addr string) (net.Conn, error) {
-	if !OutgoingAccessAllowed {
-		host, _, err := net.SplitHostPort(addr)
-		if err != nil {
-			return netDial(network, addr)
-		}
-		if host != "localhost" {
-			ip := net.ParseIP(host)
-			if ip == nil || !ip.IsLoopback() {
-				return nil, fmt.Errorf("access to address %q not allowed", addr)
-			}
-		}
+func isLocalAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
 	}
-	return netDial(network, addr)
+	return host == "localhost" || net.ParseIP(host).IsLoopback()
 }

--- a/tls.go
+++ b/tls.go
@@ -19,9 +19,9 @@ func NewHttpTLSTransport(tlsConfig *tls.Config) *http.Transport {
 		Proxy:               http.ProxyFromEnvironment,
 		TLSClientConfig:     tlsConfig,
 		DisableKeepAlives:   true,
-		Dial:                dial,
 		TLSHandshakeTimeout: 10 * time.Second,
 	}
+	installHTTPDialShim(transport)
 	registerFileProtocol(transport)
 	return transport
 }


### PR DESCRIPTION
In Go 1.7, http.Transport introduced the DialContext field
which overrides the Dial field and is set in http.DefaultContext.

This means that our hack to override the Dial field to prevent
outgoing network connections in test doesn't work from
Go 1.7 onwards.

This PR fixes that. We change the tests to avoid patching
the dial call because there is no longer a single entry point,
so we use more functional checks instead, and do some
more comprehensive testing of the local address checking
logic.

(Review request: http://reviews.vapour.ws/r/5438/)