### PR TITLE
Replace Arch Linux support with "GenericLinux"

### DIFF
--- a/os/os.go
+++ b/os/os.go
@@ -14,7 +14,7 @@ const (
 	Windows
 	OSX
 	CentOS
-	Arch
+	GenericLinux
 )
 
 func (t OSType) String() string {
@@ -27,8 +27,8 @@ func (t OSType) String() string {
 		return "OSX"
 	case CentOS:
 		return "CentOS"
-	case Arch:
-		return "Arch"
+	case GenericLinux:
+		return "GenericLinux"
 	}
 	return "Unknown"
 }

--- a/os/os.go
+++ b/os/os.go
@@ -32,3 +32,21 @@ func (t OSType) String() string {
 	}
 	return "Unknown"
 }
+
+// EquivalentTo returns true if the OS type is equivalent to another
+// OS type.
+func (t OSType) EquivalentTo(t2 OSType) bool {
+	if t == t2 {
+		return true
+	}
+	return t.IsLinux() && t2.IsLinux()
+}
+
+// IsLinux returns true if the OS type is a Linux variant.
+func (t OSType) IsLinux() bool {
+	switch t {
+	case Ubuntu, CentOS, GenericLinux:
+		return true
+	}
+	return false
+}

--- a/os/os_linux.go
+++ b/os/os_linux.go
@@ -29,10 +29,6 @@ func hostOS() OSType {
 	return os
 }
 
-var defaultVersionIDs = map[string]string{
-	"arch": "rolling",
-}
-
 func updateOS(f string) (OSType, error) {
 	values, err := ReadOSRelease(f)
 	if err != nil {
@@ -41,12 +37,10 @@ func updateOS(f string) (OSType, error) {
 	switch values["ID"] {
 	case strings.ToLower(Ubuntu.String()):
 		return Ubuntu, nil
-	case strings.ToLower(Arch.String()):
-		return Arch, nil
 	case strings.ToLower(CentOS.String()):
 		return CentOS, nil
 	default:
-		return Unknown, nil
+		return GenericLinux, nil
 	}
 }
 
@@ -67,15 +61,8 @@ func ReadOSRelease(f string) (map[string]string, error) {
 		}
 		values[c[0]] = strings.Trim(c[1], "\t '\"")
 	}
-	id, ok := values["ID"]
-	if !ok {
+	if _, ok := values["ID"]; !ok {
 		return nil, errors.New("OS release file is missing ID")
-	}
-	if _, ok := values["VERSION_ID"]; !ok {
-		values["VERSION_ID"], ok = defaultVersionIDs[id]
-		if !ok {
-			return nil, errors.New("OS release file is missing VERSION_ID")
-		}
 	}
 	return values, nil
 }

--- a/os/os_test.go
+++ b/os/os_test.go
@@ -22,7 +22,11 @@ func (s *osSuite) TestHostOS(c *gc.C) {
 	case "darwin":
 		c.Assert(os, gc.Equals, OSX)
 	case "linux":
-		if os != Ubuntu && os != CentOS && os != Arch {
+		// TODO(mjs) - this should really do more by patching out
+		// osReleaseFile and testing the corner cases.
+		switch os {
+		case Ubuntu, CentOS, GenericLinux:
+		default:
 			c.Fatalf("unknown linux version: %v", os)
 		}
 	default:

--- a/os/os_test.go
+++ b/os/os_test.go
@@ -6,6 +6,7 @@ package os
 import (
 	"runtime"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 )
 
@@ -32,4 +33,25 @@ func (s *osSuite) TestHostOS(c *gc.C) {
 	default:
 		c.Fatalf("unsupported operating system: %v", runtime.GOOS)
 	}
+}
+
+func (s *osSuite) TestEquivalentTo(c *gc.C) {
+	c.Check(Ubuntu.EquivalentTo(CentOS), jc.IsTrue)
+	c.Check(Ubuntu.EquivalentTo(GenericLinux), jc.IsTrue)
+	c.Check(GenericLinux.EquivalentTo(Ubuntu), jc.IsTrue)
+	c.Check(CentOS.EquivalentTo(CentOS), jc.IsTrue)
+
+	c.Check(OSX.EquivalentTo(Ubuntu), jc.IsFalse)
+	c.Check(OSX.EquivalentTo(Windows), jc.IsFalse)
+	c.Check(GenericLinux.EquivalentTo(OSX), jc.IsFalse)
+}
+
+func (s *osSuite) TestIsLinux(c *gc.C) {
+	c.Check(Ubuntu.IsLinux(), jc.IsTrue)
+	c.Check(CentOS.IsLinux(), jc.IsTrue)
+	c.Check(GenericLinux.IsLinux(), jc.IsTrue)
+
+	c.Check(OSX.IsLinux(), jc.IsFalse)
+	c.Check(Windows.IsLinux(), jc.IsFalse)
+	c.Check(Unknown.IsLinux(), jc.IsFalse)
 }

--- a/series/series.go
+++ b/series/series.go
@@ -15,11 +15,10 @@ import (
 	"github.com/juju/utils/os"
 )
 
-var logger = loggo.GetLogger("juju.juju.series")
-
-var HostSeries = hostSeries
-
 var (
+	logger     = loggo.GetLogger("juju.juju.series")
+	HostSeries = hostSeries
+
 	seriesOnce sync.Once
 	series     string // filled in by the first call to hostSeries
 )

--- a/series/series_linux.go
+++ b/series/series_linux.go
@@ -14,6 +14,11 @@ import (
 	jujuos "github.com/juju/utils/os"
 )
 
+const (
+	genericLinuxSeries  = "genericlinux"
+	genericLinuxVersion = "genericlinux"
+)
+
 var (
 	// osReleaseFile is the name of the file that is read in order to determine
 	// the linux type release version.
@@ -33,13 +38,11 @@ func seriesFromOSRelease(values map[string]string) (string, error) {
 	switch values["ID"] {
 	case strings.ToLower(jujuos.Ubuntu.String()):
 		return getValue(ubuntuSeries, values["VERSION_ID"])
-	case strings.ToLower(jujuos.Arch.String()):
-		return getValue(archSeries, values["VERSION_ID"])
 	case strings.ToLower(jujuos.CentOS.String()):
 		codename := fmt.Sprintf("%s%s", values["ID"], values["VERSION_ID"])
 		return getValue(centosSeries, codename)
 	default:
-		return "unknown", nil
+		return genericLinuxSeries, nil
 	}
 }
 
@@ -49,7 +52,7 @@ func getValue(from map[string]string, val string) (string, error) {
 			return serie, nil
 		}
 	}
-	return "unknown", errors.New("Could not determine series")
+	return "unknown", errors.New("could not determine series")
 }
 
 // ReleaseVersion looks for the value of VERSION_ID in the content of

--- a/series/series_linux_test.go
+++ b/series/series_linux_test.go
@@ -168,17 +168,6 @@ VERSION_ID="7"
 	"centos7",
 	"",
 }, {
-	`NAME="Arch Linux"
-ID=arch
-PRETTY_NAME="Arch Linux"
-ANSI_COLOR="0;36"
-HOME_URL="https://www.archlinux.org/"
-SUPPORT_URL="https://bbs.archlinux.org/"
-BUG_REPORT_URL="https://bugs.archlinux.org/"
-`,
-	"arch",
-	"",
-}, {
 	`NAME="Ubuntu"
 VERSION="14.04.1 LTS, Trusty Tahr"
 ID=ubuntu
@@ -192,6 +181,37 @@ BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
 	"trusty",
 	"",
 }, {
+	`NAME="Arch Linux"
+ID=arch
+PRETTY_NAME="Arch Linux"
+ANSI_COLOR="0;36"
+HOME_URL="https://www.archlinux.org/"
+SUPPORT_URL="https://bbs.archlinux.org/"
+BUG_REPORT_URL="https://bugs.archlinux.org/"
+`,
+	"genericlinux",
+	"",
+}, {
+	`NAME=Fedora
+VERSION="24 (Twenty Four)"
+ID=fedora
+VERSION_ID=24
+PRETTY_NAME="Fedora 24 (Twenty Four)"
+CPE_NAME="cpe:/o:fedoraproject:fedora:24"
+HOME_URL="https://fedoraproject.org/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+`,
+	"genericlinux",
+	"",
+}, {
+	`NAME="SuSE Linux"
+ID="SuSE"
+VERSION_ID="12"
+`,
+	"genericlinux",
+	"",
+}, {
+
 	"",
 	"unknown",
 	"OS release file is missing ID",
@@ -200,14 +220,7 @@ BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
 ID="centos"
 `,
 	"unknown",
-	"OS release file is missing VERSION_ID",
-}, {
-	`NAME="SuSE Linux"
-ID="SuSE"
-VERSION_ID="12"
-`,
-	"unknown",
-	"",
+	"could not determine series",
 },
 }
 

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -47,38 +47,34 @@ func IsUnknownVersionSeriesError(err error) bool {
 	return ok
 }
 
-var defaultVersionIDs = map[string]string{
-	"arch": "rolling",
-}
-
 // seriesVersions provides a mapping between series names and versions.
 // The values here are current as of the time of writing. On Ubuntu systems, we update
 // these values from /usr/share/distro-info/ubuntu.csv to ensure we have the latest values.
 // On non-Ubuntu systems, these values provide a nice fallback option.
 // Exported so tests can change the values to ensure the distro-info lookup works.
 var seriesVersions = map[string]string{
-	"precise":     "12.04",
-	"quantal":     "12.10",
-	"raring":      "13.04",
-	"saucy":       "13.10",
-	"trusty":      "14.04",
-	"utopic":      "14.10",
-	"vivid":       "15.04",
-	"wily":        "15.10",
-	"xenial":      "16.04",
-	"win2008r2":   "win2008r2",
-	"win2012hvr2": "win2012hvr2",
-	"win2012hv":   "win2012hv",
-	"win2012r2":   "win2012r2",
-	"win2012":     "win2012",
-	"win2016":     "win2016",
-	"win2016nano": "win2016nano",
-	"win7":        "win7",
-	"win8":        "win8",
-	"win81":       "win81",
-	"win10":       "win10",
-	"centos7":     "centos7",
-	"arch":        "rolling",
+	"precise":          "12.04",
+	"quantal":          "12.10",
+	"raring":           "13.04",
+	"saucy":            "13.10",
+	"trusty":           "14.04",
+	"utopic":           "14.10",
+	"vivid":            "15.04",
+	"wily":             "15.10",
+	"xenial":           "16.04",
+	"win2008r2":        "win2008r2",
+	"win2012hvr2":      "win2012hvr2",
+	"win2012hv":        "win2012hv",
+	"win2012r2":        "win2012r2",
+	"win2012":          "win2012",
+	"win2016":          "win2016",
+	"win2016nano":      "win2016nano",
+	"win7":             "win7",
+	"win8":             "win8",
+	"win81":            "win81",
+	"win10":            "win10",
+	"centos7":          "centos7",
+	genericLinuxSeries: genericLinuxVersion,
 }
 
 // versionSeries provides a mapping between versions and series names.
@@ -86,10 +82,6 @@ var versionSeries = reverseSeriesVersion()
 
 var centosSeries = map[string]string{
 	"centos7": "centos7",
-}
-
-var archSeries = map[string]string{
-	"arch": "rolling",
 }
 
 var ubuntuSeries = map[string]string{
@@ -189,8 +181,8 @@ func GetOSFromSeries(series string) (os.OSType, error) {
 	if _, ok := centosSeries[series]; ok {
 		return os.CentOS, nil
 	}
-	if _, ok := archSeries[series]; ok {
-		return os.Arch, nil
+	if series == genericLinuxSeries {
+		return os.GenericLinux, nil
 	}
 	for _, val := range windowsVersions {
 		if val == series {

--- a/series/supportedseries_test.go
+++ b/series/supportedseries_test.go
@@ -44,8 +44,8 @@ var getOSFromSeriesTests = []struct {
 	series: "centos7",
 	want:   os.CentOS,
 }, {
-	series: "arch",
-	want:   os.Arch,
+	series: "genericlinux",
+	want:   os.GenericLinux,
 }, {
 	series: "",
 	err:    "series \"\" not valid",
@@ -72,13 +72,13 @@ func (s *supportedSeriesSuite) TestUnknownOSFromSeries(c *gc.C) {
 
 func setSeriesTestData() {
 	series.SetSeriesVersions(map[string]string{
-		"trusty":      "14.04",
-		"utopic":      "14.10",
-		"win7":        "win7",
-		"win81":       "win81",
-		"win2016nano": "win2016nano",
-		"centos7":     "centos7",
-		"arch":        "rolling",
+		"trusty":       "14.04",
+		"utopic":       "14.10",
+		"win7":         "win7",
+		"win81":        "win81",
+		"win2016nano":  "win2016nano",
+		"centos7":      "centos7",
+		"genericlinux": "genericlinux",
 	})
 }
 
@@ -90,8 +90,8 @@ func (s *supportedSeriesSuite) TestOSSupportedSeries(c *gc.C) {
 	c.Assert(supported, jc.SameContents, []string{"win7", "win81", "win2016nano"})
 	supported = series.OSSupportedSeries(os.CentOS)
 	c.Assert(supported, jc.SameContents, []string{"centos7"})
-	supported = series.OSSupportedSeries(os.Arch)
-	c.Assert(supported, jc.SameContents, []string{"arch"})
+	supported = series.OSSupportedSeries(os.GenericLinux)
+	c.Assert(supported, jc.SameContents, []string{"genericlinux"})
 }
 
 func (s *supportedSeriesSuite) TestVersionSeriesValid(c *gc.C) {

--- a/series/supportedseries_windows_test.go
+++ b/series/supportedseries_windows_test.go
@@ -29,7 +29,7 @@ func (s *supportedSeriesWindowsSuite) TestSeriesVersion(c *gc.C) {
 
 func (s *supportedSeriesWindowsSuite) TestSupportedSeries(c *gc.C) {
 	expectedSeries := []string{
-		"arch",
+		"genericlinux",
 		"centos7",
 
 		"precise",


### PR DESCRIPTION
All Linuxes which aren't Ubuntu or CentOS will be classified as GenericLinux This is part of the work to allowing the client to work on all Linux variants.

Part of the fix for: https://bugs.launchpad.net/juju/+bug/1616531