### PR TITLE
retry: new package

### DIFF
--- a/retry/example_test.go
+++ b/retry/example_test.go
@@ -1,0 +1,56 @@
+package retry_test
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/juju/utils/retry"
+)
+
+func doSomething() (int, error) { return 0, nil }
+
+func shouldRetry(error) bool { return false }
+
+func doSomethingWith(int) {}
+
+func ExampleAttempt_More() {
+	// This example shows how Attempt.More can be used to help
+	// structure an attempt loop. If the godoc example code allowed
+	// us to make the example return an error, we would uncomment
+	// the commented return statements.
+	attempts := retry.Regular{
+		Total: 1 * time.Second,
+		Delay: 250 * time.Millisecond,
+	}
+	for attempt := attempts.Start(nil); attempt.Next(); {
+		x, err := doSomething()
+		if shouldRetry(err) && attempt.More() {
+			continue
+		}
+		if err != nil {
+			// return err
+			return
+		}
+		doSomethingWith(x)
+	}
+	// return ErrTimedOut
+	return
+}
+
+func ExampleExponential() {
+	// This example shows a retry loop that will retry an
+	// HTTP POST request with an exponential backoff
+	// for up to 30s.
+	strategy := retry.LimitTime(30*time.Second,
+		retry.Exponential{
+			Initial: 10 * time.Millisecond,
+			Factor:  1.5,
+		},
+	)
+	for a := retry.Start(strategy, nil); a.Next(); {
+		if reply, err := http.Post("http://example.com/form", "", nil); err == nil {
+			reply.Body.Close()
+			break
+		}
+	}
+}

--- a/retry/exp.go
+++ b/retry/exp.go
@@ -1,0 +1,50 @@
+package retry
+
+import (
+	"time"
+)
+
+// Exponential represents an exponential backoff retry strategy.
+// To limit the number of attempts or their overall duration, wrap
+// this in LimitCount or LimitDuration.
+type Exponential struct {
+	// Initial holds the initial delay.
+	Initial time.Duration
+	// Factor holds the factor that the delay time will be multiplied
+	// by on each iteration.
+	Factor float64
+	// MaxDelay holds the maximum delay between the start
+	// of attempts. If this is zero, there is no maximum delay.
+	MaxDelay time.Duration
+}
+
+type exponentialTimer struct {
+	strategy Exponential
+	start    time.Time
+	end      time.Time
+	delay    time.Duration
+}
+
+// NewTimer implements Strategy.NewTimer.
+func (r Exponential) NewTimer(now time.Time) Timer {
+	return &exponentialTimer{
+		strategy: r,
+		start:    now,
+		delay:    r.Initial,
+	}
+}
+
+// NextSleep implements Timer.NextSleep.
+func (a *exponentialTimer) NextSleep(now time.Time) (time.Duration, bool) {
+	sleep := a.delay - now.Sub(a.start)
+	if sleep <= 0 {
+		sleep = 0
+	}
+	// Set the start of the next try.
+	a.start = now.Add(sleep)
+	a.delay = time.Duration(float64(a.delay) * a.strategy.Factor)
+	if a.strategy.MaxDelay > 0 && a.delay > a.strategy.MaxDelay {
+		a.delay = a.strategy.MaxDelay
+	}
+	return sleep, true
+}

--- a/retry/package_test.go
+++ b/retry/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package retry_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/retry/regular.go
+++ b/retry/regular.go
@@ -1,0 +1,67 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package retry
+
+import (
+	"time"
+
+	"github.com/juju/utils/clock"
+)
+
+// Regular represents a strategy that repeats at regular intervals.
+type Regular struct {
+	// Total specifies the total duration of the attempt.
+	Total time.Duration
+
+	// Delay specifies the interval between the start of each try
+	// in the burst. If an try takes longer than Delay, the
+	// next try will happen immediately.
+	Delay time.Duration
+
+	// Min holds the minimum number of retries. It overrides Total.
+	// To limit the maximum number of retries, use LimitCount.
+	Min int
+}
+
+// regularTimer holds a running instantiation of the Regular timer.
+type regularTimer struct {
+	strategy Regular
+	count    int
+	// start holds when the current try started.
+	start time.Time
+	end   time.Time
+}
+
+// Start is short for Start(r, clk, nil)
+func (r Regular) Start(clk clock.Clock) *Attempt {
+	return Start(r, clk)
+}
+
+// NewTimer implements Strategy.NewTimer.
+func (r Regular) NewTimer(now time.Time) Timer {
+	return &regularTimer{
+		strategy: r,
+		start:    now,
+		end:      now.Add(r.Total),
+	}
+}
+
+// NextSleep implements Timer.NextSleep.
+func (a *regularTimer) NextSleep(now time.Time) (time.Duration, bool) {
+	sleep := a.strategy.Delay - now.Sub(a.start)
+	if sleep <= 0 {
+		sleep = 0
+	}
+	a.count++
+	// Set the start of the next try.
+	a.start = now.Add(sleep)
+	if a.count < a.strategy.Min {
+		return sleep, true
+	}
+	// The next try is after the end - no more attempts.
+	if a.start.After(a.end) {
+		return 0, false
+	}
+	return sleep, true
+}

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,0 +1,158 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// Package retry provides a framework for retrying actions.
+// It does not itself invoke the action to be retried, but
+// is intended to be used in a retry loop.
+//
+// The basic usage is as follows:
+//
+//	for a := someStrategy.Start(); a.Next(); {
+//		try()
+//	}
+//
+// See examples for details of suggested usage.
+package retry
+
+import (
+	"time"
+
+	"github.com/juju/utils/clock"
+)
+
+// Strategy is implemented by types that represent a retry strategy.
+//
+// Note: You probably won't need to implement a new strategy - the existing types
+// and functions are intended to be sufficient for most purposes.
+type Strategy interface {
+	// NewTimer is called when the strategy is started - it is
+	// called with the time that the strategy is started and returns
+	// an object that is used to find out how long to sleep before
+	// each retry attempt.
+	NewTimer(now time.Time) Timer
+}
+
+// Timer represents a source of timing events for a retry strategy.
+type Timer interface {
+	// NextSleep is called with the time that Next or More has been
+	// called and returns the length of time to sleep before the
+	// next retry. If no more attempts should be made it should
+	// return false, and the returned duration will be ignored.
+	//
+	// Note that NextSleep is called once after each iteration has
+	// completed, assuming the retry loop is continuing.
+	NextSleep(now time.Time) (time.Duration, bool)
+}
+
+// Attempt represents a running retry attempt.
+type Attempt struct {
+	clock clock.Clock
+	stop  <-chan struct{}
+	timer Timer
+
+	// next holds when the next attempt should start.
+	// It is valid only when known is true.
+	next time.Time
+
+	// count holds the iteration count.
+	count int
+
+	// known holds whether next and running are known.
+	known bool
+
+	// running holds whether the attempt is still going.
+	running bool
+
+	// stopped holds whether the attempt has been stopped.
+	stopped bool
+}
+
+// Start begins a new sequence of attempts for the given strategy using
+// the given Clock implementation for time keeping. If clk is
+// nil, clock.WallClock will be used.
+func Start(strategy Strategy, clk clock.Clock) *Attempt {
+	return StartWithCancel(strategy, clk, nil)
+}
+
+// StartWithCancel is like Start except that if a value
+// is received on stop while waiting, the attempt will be aborted.
+func StartWithCancel(strategy Strategy, clk clock.Clock, stop <-chan struct{}) *Attempt {
+	if clk == nil {
+		clk = clock.WallClock
+	}
+	now := clk.Now()
+	return &Attempt{
+		clock:   clk,
+		stop:    stop,
+		timer:   strategy.NewTimer(now),
+		known:   true,
+		running: true,
+		next:    now,
+	}
+}
+
+// Next reports whether another attempt should be made, waiting as
+// necessary until it's time for the attempt. It always returns true the
+// first time it is called unless a value is received on the stop
+// channel - we are guaranteed to make at least one attempt unless
+// stopped.
+func (a *Attempt) Next() bool {
+	if !a.More() {
+		return false
+	}
+	sleep := a.next.Sub(a.clock.Now())
+	if sleep <= 0 {
+		// We're not going to sleep for any length of time,
+		// so guarantee that we respect the stop channel. This
+		// ensures that we make no attempts if Next is called
+		// with a value available on the stop channel.
+		select {
+		case <-a.stop:
+			a.stopped = true
+			a.running = false
+			return false
+		default:
+			a.known = false
+			a.count++
+			return true
+		}
+	}
+	select {
+	case <-a.clock.After(sleep):
+		a.known = false
+		a.count++
+	case <-a.stop:
+		a.running = false
+		a.stopped = true
+	}
+	return a.running
+}
+
+// More reports whether there are more retry attempts to be made. It
+// does not sleep.
+//
+// If More returns false, Next will return false. If More returns true,
+// Next will return true except when the attempt has been explicitly
+// stopped via the stop channel.
+func (a *Attempt) More() bool {
+	if !a.known {
+		now := a.clock.Now()
+		sleepDuration, running := a.timer.NextSleep(now)
+		a.next, a.running, a.known = now.Add(sleepDuration), running, true
+	}
+	return a.running
+}
+
+// Stopped reports whether the attempt has terminated because
+// a value was received on the stop channel.
+func (a *Attempt) Stopped() bool {
+	return a.stopped
+}
+
+// Count returns the current attempt count number, starting at 1.
+// It returns 0 if called before Next is called.
+// When the loop has terminated, it holds the total number
+// of retries made.
+func (a *Attempt) Count() int {
+	return a.count
+}

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -1,0 +1,335 @@
+// Copyright 2011, 2012, 2013 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package retry_test
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils/clock"
+	"github.com/juju/utils/retry"
+)
+
+type retrySuite struct{}
+
+var _ = gc.Suite(&retrySuite{})
+
+func (*retrySuite) TestAttemptTiming(c *gc.C) {
+	testAttempt := retry.Regular{
+		Total: 0.25e9,
+		Delay: 0.1e9,
+	}
+	want := []time.Duration{0, 0.1e9, 0.2e9, 0.2e9}
+	got := make([]time.Duration, 0, len(want)) // avoid allocation when testing timing
+	t0 := time.Now()
+	a := testAttempt.Start(nil)
+	for a.Next() {
+		got = append(got, time.Now().Sub(t0))
+	}
+	got = append(got, time.Now().Sub(t0))
+	c.Assert(a.Stopped(), gc.Equals, false)
+	c.Assert(got, gc.HasLen, len(want))
+	const margin = 0.01e9
+	for i, got := range want {
+		lo := want[i] - margin
+		hi := want[i] + margin
+		if got < lo || got > hi {
+			c.Errorf("attempt %d want %g got %g", i, want[i].Seconds(), got.Seconds())
+		}
+	}
+}
+
+func (*retrySuite) TestAttemptNextMore(c *gc.C) {
+	a := retry.Regular{}.Start(nil)
+	c.Assert(a.Next(), gc.Equals, true)
+	c.Assert(a.Next(), gc.Equals, false)
+
+	a = retry.Regular{}.Start(nil)
+	c.Assert(a.Next(), gc.Equals, true)
+	c.Assert(a.More(), gc.Equals, false)
+	c.Assert(a.Next(), gc.Equals, false)
+
+	a = retry.Regular{Total: 2e8}.Start(nil)
+	c.Assert(a.Next(), gc.Equals, true)
+	c.Assert(a.More(), gc.Equals, true)
+	time.Sleep(2e8)
+	c.Assert(a.More(), gc.Equals, true)
+	c.Assert(a.Next(), gc.Equals, true)
+	c.Assert(a.Next(), gc.Equals, false)
+
+	a = retry.Regular{Total: 1e8, Min: 2}.Start(nil)
+	time.Sleep(1e8)
+	c.Assert(a.Next(), gc.Equals, true)
+	c.Assert(a.More(), gc.Equals, true)
+	c.Assert(a.Next(), gc.Equals, true)
+	c.Assert(a.More(), gc.Equals, false)
+	c.Assert(a.Next(), gc.Equals, false)
+}
+
+func (*retrySuite) TestAttemptWithStop(c *gc.C) {
+	stop := make(chan struct{})
+	close(stop)
+	done := make(chan struct{})
+	go func() {
+		strategy := retry.Regular{
+			Delay: 5 * time.Second,
+			Total: 30 * time.Second,
+		}
+		a := retry.StartWithCancel(strategy, nil, stop)
+		for a.Next() {
+			c.Errorf("unexpected attempt")
+		}
+		c.Check(a.Stopped(), gc.Equals, true)
+		close(done)
+	}()
+	assertReceive(c, done, "attempt loop abort")
+}
+
+func (*retrySuite) TestAttemptWithLaterStop(c *gc.C) {
+	clock := testing.NewClock(time.Now())
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	progress := make(chan struct{}, 10)
+	go func() {
+		strategy := retry.Regular{
+			Delay: 5 * time.Second,
+			Total: 30 * time.Second,
+		}
+		a := retry.StartWithCancel(strategy, clock, stop)
+		for a.Next() {
+			progress <- struct{}{}
+		}
+		c.Check(a.Stopped(), gc.Equals, true)
+		close(done)
+	}()
+	assertReceive(c, progress, "progress")
+	clock.Advance(5 * time.Second)
+	assertReceive(c, progress, "progress")
+	clock.Advance(2 * time.Second)
+	close(stop)
+	assertReceive(c, done, "attempt loop abort")
+	select {
+	case <-progress:
+		c.Fatalf("unxpected loop iteration after stop")
+	default:
+	}
+}
+
+func (*retrySuite) TestAttemptWithMockClock(c *gc.C) {
+	clock := testing.NewClock(time.Now())
+	strategy := retry.Regular{
+		Delay: 5 * time.Second,
+		Total: 30 * time.Second,
+	}
+	progress := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		for a := strategy.Start(clock); a.Next(); {
+			progress <- struct{}{}
+		}
+		close(done)
+	}()
+	assertReceive(c, progress, "progress first time")
+	clock.Advance(5 * time.Second)
+	assertReceive(c, progress, "progress second time")
+	clock.Advance(5 * time.Second)
+	assertReceive(c, progress, "progress third time")
+	clock.Advance(30 * time.Second)
+	assertReceive(c, progress, "progress fourth time")
+	assertReceive(c, done, "loop finish")
+}
+
+type strategyTest struct {
+	about      string
+	strategy   retry.Strategy
+	calls      []nextCall
+	terminates bool
+}
+
+type nextCall struct {
+	// t holds the time since the timer was started that
+	// the Next call will be made.
+	t time.Duration
+	// delay holds the length of time that a call made at
+	// time t is expected to sleep for.
+	sleep time.Duration
+}
+
+var strategyTests = []strategyTest{{
+	about: "regular retry (same params as TestAttemptTiming)",
+	strategy: retry.Regular{
+		Total: 0.25e9,
+		Delay: 0.1e9,
+	},
+	calls: []nextCall{
+		{0, 0},
+		{0, 0.1e9},
+		{0.1e9, 0.1e9},
+		{0.2e9, 0},
+	},
+	terminates: true,
+}, {
+	about: "regular retry with calls at different times",
+	strategy: retry.Regular{
+		Total: 2.5e9,
+		Delay: 1e9,
+	},
+	calls: []nextCall{
+		{0.5e9, 0},
+		{0.5e9, 0.5e9},
+		{1.1e9, 0.9e9},
+		{2.2e9, 0},
+	},
+	terminates: true,
+}, {
+	about: "regular retry with call after next deadline",
+	strategy: retry.Regular{
+		Total: 3.5e9,
+		Delay: 1e9,
+	},
+	calls: []nextCall{
+		{0.5e9, 0},
+		// We call Next at well beyond the deadline,
+		// so we get a zero delay, but subsequent events
+		// resume pace.
+		{2e9, 0},
+		{2.1e9, 0.9e9},
+		{3e9, 0},
+	},
+	terminates: true,
+}, {
+	about: "exponential retry",
+	strategy: retry.Exponential{
+		Initial: 1e9,
+		Factor:  2,
+	},
+	calls: []nextCall{
+		{0, 0},
+		{0.1e9, 0.9e9},
+		{1e9, 2e9},
+		{3e9, 4e9},
+		{7e9, 8e9},
+	},
+}, {
+	about: "time-limited exponential retry",
+	strategy: retry.LimitTime(5e9, retry.Exponential{
+		Initial: 1e9,
+		Factor:  2,
+	}),
+	calls: []nextCall{
+		{0, 0},
+		{0.1e9, 0.9e9},
+		{1e9, 2e9},
+		{3e9, 0},
+	},
+	terminates: true,
+}, {
+	about: "count-limited exponential retry",
+	strategy: retry.LimitCount(2, retry.Exponential{
+		Initial: 1e9,
+		Factor:  2,
+	}),
+	calls: []nextCall{
+		{0, 0},
+		{0.1e9, 0.9e9},
+		{1e9, 0},
+	},
+	terminates: true,
+}}
+
+func (*retrySuite) TestStrategies(c *gc.C) {
+	for i, test := range strategyTests {
+		c.Logf("test %d: %s", i, test.about)
+		testStrategy(c, test)
+	}
+}
+
+func testStrategy(c *gc.C, test strategyTest) {
+	t0 := time.Now()
+	clk := &mockClock{
+		now: t0,
+	}
+	a := retry.Start(test.strategy, clk)
+	for i, call := range test.calls {
+		c.Logf("call %d - %v", i, call.t)
+		clk.now = t0.Add(call.t)
+		ok := a.Next()
+		expectTerminate := test.terminates && i == len(test.calls)-1
+		c.Assert(ok, gc.Equals, !expectTerminate)
+		if got, want := clk.now.Sub(t0), call.t+call.sleep; !closeTo(got, want) {
+			c.Fatalf("incorrect time after Next; got %v want %v", got, want)
+		}
+		if ok {
+			c.Assert(a.Count(), gc.Equals, i+1)
+		}
+	}
+}
+
+func (*retrySuite) TestGapBetweenMoreAndNext(c *gc.C) {
+	t0 := time.Now().UTC()
+	clk := &mockClock{
+		now: t0,
+	}
+	a := (&retry.Regular{
+		Min:   3,
+		Delay: time.Second,
+	}).Start(clk)
+	c.Assert(a.Next(), gc.Equals, true)
+	c.Assert(clk.now, gc.Equals, t0)
+
+	clk.now = clk.now.Add(500 * time.Millisecond)
+	// Sanity check that the first iteration sleeps for half a second.
+	c.Assert(a.More(), gc.Equals, true)
+	c.Assert(a.Next(), gc.Equals, true)
+	c.Assert(clk.now.Sub(t0), gc.Equals, t0.Add(time.Second).Sub(t0))
+
+	clk.now = clk.now.Add(500 * time.Millisecond)
+	c.Assert(a.More(), gc.Equals, true)
+
+	// Add a delay between calling More and Next.
+	// Next should wait until the correct time anyway.
+	clk.now = clk.now.Add(250 * time.Millisecond)
+	c.Assert(a.More(), gc.Equals, true)
+	c.Assert(a.Next(), gc.Equals, true)
+	c.Assert(clk.now.Sub(t0), gc.Equals, t0.Add(2*time.Second).Sub(t0))
+}
+
+// closeTo reports whether d0 and d1 are close enough
+// to one another to cater for inaccuracies of floating point arithmetic.
+func closeTo(d0, d1 time.Duration) bool {
+	const margin = 20 * time.Nanosecond
+	diff := d1 - d0
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff < margin
+}
+
+type mockClock struct {
+	clock.Clock
+
+	now   time.Time
+	sleep func(d time.Duration)
+}
+
+func (c *mockClock) After(d time.Duration) <-chan time.Time {
+	c.now = c.now.Add(d)
+	ch := make(chan time.Time)
+	close(ch)
+	return ch
+}
+
+func (c *mockClock) Now() time.Time {
+	return c.now
+}
+
+func assertReceive(c *gc.C, ch <-chan struct{}, what string) {
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		c.Fatalf("timed out waiting for %s", what)
+	}
+}

--- a/retry/strategy.go
+++ b/retry/strategy.go
@@ -1,0 +1,60 @@
+package retry
+
+import (
+	"time"
+)
+
+type strategyFunc func(now time.Time) Timer
+
+// NewTimer implements Strategy.NewTimer.
+func (f strategyFunc) NewTimer(now time.Time) Timer {
+	return f(now)
+}
+
+// LimitCount limits the number of attempts that the given
+// strategy will perform to n. Note that all strategies
+// will allow at least one attempt.
+func LimitCount(n int, strategy Strategy) Strategy {
+	return strategyFunc(func(now time.Time) Timer {
+		return &countLimitTimer{
+			timer:  strategy.NewTimer(now),
+			remain: n,
+		}
+	})
+}
+
+type countLimitTimer struct {
+	timer  Timer
+	remain int
+}
+
+func (t *countLimitTimer) NextSleep(now time.Time) (time.Duration, bool) {
+	if t.remain--; t.remain <= 0 {
+		return 0, false
+	}
+	return t.timer.NextSleep(now)
+}
+
+// LimitTime limits the given strategy such that no attempt will
+// made after the given duration has elapsed.
+func LimitTime(limit time.Duration, strategy Strategy) Strategy {
+	return strategyFunc(func(now time.Time) Timer {
+		return &timeLimitTimer{
+			timer: strategy.NewTimer(now),
+			end:   now.Add(limit),
+		}
+	})
+}
+
+type timeLimitTimer struct {
+	timer Timer
+	end   time.Time
+}
+
+func (t *timeLimitTimer) NextSleep(now time.Time) (time.Duration, bool) {
+	sleep, ok := t.timer.NextSleep(now)
+	if ok && now.Add(sleep).After(t.end) {
+		return 0, false
+	}
+	return sleep, ok
+}


### PR DESCRIPTION
The plan is that this should eventually replace utils.Attempt
and github.com/juju/retry.

It provides functionality for stopping and clock mocking and for pluggable
strategies.

It is (arguably) quite a bit simpler to use than github.com/juju/retry and
the usage remains basically compatible with utils.Attempt, so
only minor code changes will be needed to change the existing
code base to use it.
