### PR TITLE
HostSeries no longer panics

### DIFF
--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -8,7 +8,13 @@ import (
 	"sync"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/utils/os"
+)
+
+var (
+	// TODO(katco): Remove globals (lp:1633571)
+	logger = loggo.GetLogger("juju.juju.series")
 )
 
 type unknownOSForSeriesError string


### PR DESCRIPTION
This is to help address lp:1633495.

HostSeries unecessarily panics. Any function that panics should be prepended with the keyword "Must". I have introduced a function which does just this in case callers want to continue to panic.

Also removed unecessary global variable referencing an unexported function.