### PR TITLE
Better support for GetOSFromSeries

### DIFF
--- a/series/export_linux_test.go
+++ b/series/export_linux_test.go
@@ -8,3 +8,11 @@ var (
 	ReadSeries    = readSeries
 	OSReleaseFile = &osReleaseFile
 )
+
+func SetUbuntuSeries(value map[string]string) func() {
+	origSeries := ubuntuSeries
+	ubuntuSeries = value
+	return func() {
+		ubuntuSeries = origSeries
+	}
+}

--- a/series/supportedseries.go
+++ b/series/supportedseries.go
@@ -68,6 +68,8 @@ var seriesVersions = map[string]string{
 	"vivid":            "15.04",
 	"wily":             "15.10",
 	"xenial":           "16.04",
+	"yakkety":          "16.10",
+	"zesty":            "17.04",
 	"win2008r2":        "win2008r2",
 	"win2012hvr2":      "win2012hvr2",
 	"win2012hv":        "win2012hv",
@@ -100,6 +102,8 @@ var ubuntuSeries = map[string]string{
 	"vivid":   "15.04",
 	"wily":    "15.10",
 	"xenial":  "16.04",
+	"yakkety": "16.10",
+	"zesty":   "17.04",
 }
 
 // ubuntuLts provides a lookup for current LTS series.  Like seriesVersions,
@@ -181,6 +185,15 @@ func GetOSFromSeries(series string) (os.OSType, error) {
 	if series == "" {
 		return os.Unknown, errors.NotValidf("series %q", series)
 	}
+	osType, err := getOSFromSeries(series)
+	if err == nil {
+		return osType, nil
+	}
+	updateSeriesVersionsOnce()
+	return getOSFromSeries(series)
+}
+
+func getOSFromSeries(series string) (os.OSType, error) {
 	if _, ok := ubuntuSeries[series]; ok {
 		return os.Ubuntu, nil
 	}

--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -68,6 +68,20 @@ func (s *supportedSeriesSuite) TestUpdateSeriesVersions(c *gc.C) {
 	checkSeries()
 }
 
+func (s *supportedSeriesSuite) TestOSSeries(c *gc.C) {
+	cleanup := series.SetUbuntuSeries(make(map[string]string))
+	defer cleanup()
+	d := c.MkDir()
+	filename := filepath.Join(d, "ubuntu.csv")
+	err := ioutil.WriteFile(filename, []byte(distInfoData), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	s.PatchValue(series.DistroInfo, filename)
+
+	osType, err := series.GetOSFromSeries("raring")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(osType, gc.Equals, os.Ubuntu)
+}
+
 const distInfoData = `version,codename,series,created,release,eol,eol-server
 4.10,Warty Warthog,warty,2004-03-05,2004-10-20,2006-04-30
 5.04,Hoary Hedgehog,hoary,2004-10-20,2005-04-08,2006-10-31


### PR DESCRIPTION
When calling GetOSFromSeries(), on Linux, if the series was not found, there was no call to update distro info data to pull in the last series info. This is fixed.

Also, add in yakkety and zesty so there work without the need for the distro info lookup.