### PR TITLE
ssh: Add StripCRReader for gocrypto on windows

### DIFF
--- a/ssh/ssh_gocrypto.go
+++ b/ssh/ssh_gocrypto.go
@@ -154,7 +154,7 @@ func (c *goCryptoCommand) ensureSession() (*ssh.Session, error) {
 	}
 	c.client = client
 	c.sess = sess
-	c.sess.Stdin = c.stdin
+	c.sess.Stdin = WrapStdin(c.stdin)
 	c.sess.Stdout = c.stdout
 	c.sess.Stderr = c.stderr
 	return sess, nil

--- a/ssh/stream.go
+++ b/ssh/stream.go
@@ -1,0 +1,36 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package ssh
+
+import (
+	"bytes"
+	"io"
+)
+
+// stripCR implements an io.Reader wrapper that removes carriage return bytes.
+type stripCR struct {
+	reader io.Reader
+}
+
+// StripCRReader returns a new io.Reader wrapper that strips carriage returns.
+func StripCRReader(reader io.Reader) io.Reader {
+	if reader == nil {
+		return nil
+	}
+	return &stripCR{reader: reader}
+}
+
+var byteEmpty = []byte{}
+var byteCR = []byte{'\r'}
+
+// Read implements io.Reader interface.
+// This copies data around much more than needed so should be optimized if
+// used on a performance critical path.
+func (s *stripCR) Read(bufOut []byte) (int, error) {
+	bufTemp := make([]byte, len(bufOut))
+	n, err := s.reader.Read(bufTemp)
+	bufReplaced := bytes.Replace(bufTemp[:n], byteCR, byteEmpty, -1)
+	copy(bufOut, bufReplaced)
+	return len(bufReplaced), err
+}

--- a/ssh/stream_test.go
+++ b/ssh/stream_test.go
@@ -1,0 +1,47 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package ssh_test
+
+import (
+	"io/ioutil"
+	"strings"
+	"testing/iotest"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils/ssh"
+)
+
+type SSHStreamSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&SSHStreamSuite{})
+
+func (s *SSHStreamSuite) TestNewStripCRNil(c *gc.C) {
+	reader := ssh.StripCRReader(nil)
+	c.Assert(reader, gc.IsNil)
+}
+
+func (s *SSHStreamSuite) TestStripCR(c *gc.C) {
+	reader := ssh.StripCRReader(strings.NewReader("One\r\nTwo"))
+	output, err := ioutil.ReadAll(reader)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(string(output), gc.Equals, "One\nTwo")
+}
+
+func (s *SSHStreamSuite) TestStripCROneByte(c *gc.C) {
+	reader := ssh.StripCRReader(strings.NewReader("One\r\r\rTwo"))
+	output, err := ioutil.ReadAll(iotest.OneByteReader(reader))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(string(output), gc.Equals, "OneTwo")
+}
+
+func (s *SSHStreamSuite) TestStripCRError(c *gc.C) {
+	reader := ssh.StripCRReader(strings.NewReader("One\r\r\rTwo"))
+	_, err := ioutil.ReadAll(iotest.TimeoutReader(reader))
+	c.Assert(err.Error(), gc.Equals, "timeout")
+}

--- a/ssh/stream_wrapper_unix.go
+++ b/ssh/stream_wrapper_unix.go
@@ -1,0 +1,15 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// +build !windows
+
+package ssh
+
+import (
+	"io"
+)
+
+// WrapStdin returns the original stdin stream on nix platforms.
+func WrapStdin(reader io.Reader) io.Reader {
+	return reader
+}

--- a/ssh/stream_wrapper_windows.go
+++ b/ssh/stream_wrapper_windows.go
@@ -1,0 +1,13 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package ssh
+
+import (
+	"io"
+)
+
+// WrapStdin returns stdin with carriage returns stripped on windows.
+func WrapStdin(reader io.Reader) io.Reader {
+	return StripCRReader(reader)
+}


### PR DESCRIPTION
Fixes lp:1468752 by removing carriage returns from textual stdin
stream on windows when using gocrypto to communicate with remote
machine.

This is part one of making ssh from windows to a unix machine
more usable. Notably, this doesn't enable the passing of control
codes through to the remote shell, so for instance using a text
editor is still problematic.

QA steps
----

* Build juju using this version of utils for windows.
* Bootstrap with the resultant juju.exe
* `juju switch controller`
* `juju.exe ssh 0`
* On remote machine, `ls ~`
* See outout from ls and no other kipple.
* Run other commands as well, note `vi somefile` is still not usable.