### PR TITLE
Revert back cert parsing functions

### DIFF
--- a/cert/cert.go
+++ b/cert/cert.go
@@ -251,3 +251,40 @@ func getPublicKey(p interface{}) interface{} {
 		return nil
 	}
 }
+
+// ParseCert parses the given PEM-formatted X509 certificate.
+func ParseCert(certPEM string) (*x509.Certificate, error) {
+	certPEMData := []byte(certPEM)
+	for len(certPEMData) > 0 {
+		var certBlock *pem.Block
+		certBlock, certPEMData = pem.Decode(certPEMData)
+		if certBlock == nil {
+			break
+		}
+		if certBlock.Type == "CERTIFICATE" {
+			cert, err := x509.ParseCertificate(certBlock.Bytes)
+			return cert, err
+		}
+	}
+	return nil, errors.New("no certificates found")
+}
+
+// ParseCertAndKey parses the given PEM-formatted X509 certificate
+// and RSA private key.
+func ParseCertAndKey(certPEM, keyPEM string) (*x509.Certificate, *rsa.PrivateKey, error) {
+	tlsCert, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert, err := x509.ParseCertificate(tlsCert.Certificate[0])
+	if err != nil {
+		return nil, nil, err
+	}
+
+	key, ok := tlsCert.PrivateKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, nil, fmt.Errorf("private key with unexpected type %T", key)
+	}
+	return cert, key, nil
+}


### PR DESCRIPTION
Revert back cert parsing functions that I accidentally removed in a previous patch.