### PR TITLE
Add function to return a public key from an x509 certificate

### DIFF
--- a/cert/cert.go
+++ b/cert/cert.go
@@ -16,9 +16,11 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"os"
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils"
 )
 
 // OtherName type for asn1 encoding
@@ -308,4 +310,19 @@ func ComputePublicKey(certPEM string) (string, error){
 		Bytes: marshalledPubKey,
 	})
 	return string(keyPEMData), nil
+}
+
+// StoreDefaultX509Cert takes a certificate and store it in the given
+// config location, using default names.
+func StoreDefaultX509Cert(location, pem, key, public string) (error) {
+	for file, content := range map[string]string{ "/juju-cert.pem": pem, "/juju-cert.key": key,
+						      "/juju-cert.pub": public } {
+		if _, err := os.Stat(location + file); os.IsNotExist(err) {
+			err := utils.AtomicWriteFile(location + file, []byte(content), 0600)
+			if err != nil {
+				return errors.Annotatef(err, "cannot write x509 certificate file: %s", location + file)
+			}
+		}
+	}
+	return nil
 }

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -292,3 +292,20 @@ func ParseCertAndKey(certPEM, keyPEM string) (*x509.Certificate, *rsa.PrivateKey
 	}
 	return cert, key, nil
 }
+
+// ComputePublicKey generates a public key from certPEM string
+func ComputePublicKey(certPEM string) (string, error){
+	cert, err := ParseCert(certPEM)
+	if err != nil {
+		return "", err
+	}
+	marshalledPubKey, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
+	if err != nil {
+		return "", err
+	}
+	keyPEMData := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PUBLIC KEY",
+		Bytes: marshalledPubKey,
+	})
+	return string(keyPEMData), nil
+}

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -219,6 +219,12 @@ func (certSuite) TestNewClientCertRSASize(c *gc.C) {
 	}
 }
 
+func (certSuite) TestComputePublicKey(c *gc.C) {
+	computedPublicKey, err := cert.ComputePublicKey(caCertPEM)
+	c.Assert(err, gc.IsNil)
+	c.Assert(computedPublicKey, gc.Equals, caPubKeyPEM)
+}
+
 var (
 	caCertPEM = `
 -----BEGIN CERTIFICATE-----
@@ -247,5 +253,11 @@ M/vY0x5mekIYai8/tFSEG9PJ3ZkpEy0CIQCo9B3YxwI1Un777vbs903iQQeiWP+U
 EAHnOQvhLgDxpQIgGkpml+9igW5zoOH+h02aQBLwEoXz7tw/YW0HFrCcE70CIGkS
 ve4WjiEqnQaHNAPy0hY/1DfIgBOSpOfnkFHOk9vX
 -----END RSA PRIVATE KEY-----
+`
+
+	caPubKeyPEM = `-----BEGIN RSA PUBLIC KEY-----
+MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAL+0X+1zl2vt1wI41Q+RnlltJyaJmtwC
+bHRhREXVGU7t0kTMMNERxqLnuNUyWRz90Rg8s9XvOtCqNYW7mypGrFECAwEAAQ==
+-----END RSA PUBLIC KEY-----
 `
 )

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -15,6 +15,7 @@ import (
 	"io/ioutil"
 	"math/big"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -23,6 +24,7 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/cert"
 	gc "gopkg.in/check.v1"
+	"github.com/juju/juju/juju/osenv"
 )
 
 func TestAll(t *testing.T) {
@@ -223,6 +225,24 @@ func (certSuite) TestComputePublicKey(c *gc.C) {
 	computedPublicKey, err := cert.ComputePublicKey(caCertPEM)
 	c.Assert(err, gc.IsNil)
 	c.Assert(computedPublicKey, gc.Equals, caPubKeyPEM)
+}
+
+func (certSuite) TestStoreDefaultX509Cert(c *gc.C) {
+	certdir := osenv.JujuXDGDataHomePath("x509")
+	c.Assert(cert.StoreDefaultX509Cert(certdir, caCertPEM, caKeyPEM, caPubKeyPEM), gc.IsNil)
+	_, err := os.Stat(certdir)
+	c.Assert(err, gc.IsNil)
+	_, err = os.Stat(certdir + "/juju-cert.pem")
+	c.Assert(err, gc.IsNil)
+	_, err = os.Stat(certdir + "/juju-cert.key")
+	c.Assert(err, gc.IsNil)
+	_, err = os.Stat(certdir + "/juju-cert.pub")
+	c.Assert(err, gc.IsNil)
+	_, _, err = cert.ParseCertAndKey(caCertPEM, caKeyPEM)
+	c.Assert(err, gc.IsNil)
+	pubkey, err := cert.ComputePublicKey(caCertPEM)
+	c.Assert(err, gc.IsNil)
+	c.Assert(pubkey, gc.Equals, caPubKeyPEM)
 }
 
 var (


### PR DESCRIPTION
The public key will be ready to be written in a config file. This is valuable to
generate a certificateduring the initial configuration of juju client that will
become a default certificate in case of trying to use lxd https remotes.