### PR TITLE
Allow specifying a user to run script as.

### DIFF
--- a/exec/exec.go
+++ b/exec/exec.go
@@ -113,7 +113,7 @@ func shellAndArgs(tempDir, script, user string) (string, []string, error) {
 				return "", nil, errors.Annotatef(err, "making tempdir readable by %q", user)
 			}
 			cmd = "/bin/su"
-			args = []string{user, "-c", fmt.Sprintf("/bin/bash %s", scriptFile)}
+			args = []string{user, "--login", "--command", fmt.Sprintf("/bin/bash %s", scriptFile)}
 		}
 	}
 	err := ioutil.WriteFile(scriptFile, []byte(script), 0644)

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -6,6 +6,7 @@ package exec
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -34,6 +35,7 @@ type RunParams struct {
 	Environment []string
 	Clock       clock.Clock
 	KillProcess func(*os.Process) error
+	User        string
 
 	tempDir string
 	stdout  *bytes.Buffer
@@ -80,7 +82,7 @@ func mergeEnvironment(env []string) []string {
 // shellAndArgs returns the name of the shell command and arguments to run the
 // specified script. shellAndArgs may write into the provided temporary
 // directory, which will be maintained until the process exits.
-func shellAndArgs(tempDir, script string) (string, []string, error) {
+func shellAndArgs(tempDir, script, user string) (string, []string, error) {
 	var scriptFile string
 	var cmd string
 	var args []string
@@ -101,10 +103,20 @@ func shellAndArgs(tempDir, script string) (string, []string, error) {
 		script = "trap {Write-Error $_; exit 1}\n" + script
 	default:
 		scriptFile = filepath.Join(tempDir, "script.sh")
-		cmd = "/bin/bash"
-		args = []string{scriptFile}
+		if user == "" {
+			cmd = "/bin/bash"
+			args = []string{scriptFile}
+		} else {
+			// Need to make the tempDir readable by all so the user can see it.
+			err := os.Chmod(tempDir, 0755)
+			if err != nil {
+				return "", nil, errors.Annotatef(err, "making tempdir readable by %q", user)
+			}
+			cmd = "/bin/su"
+			args = []string{user, "-c", fmt.Sprintf("/bin/bash %s", scriptFile)}
+		}
 	}
-	err := ioutil.WriteFile(scriptFile, []byte(script), 0600)
+	err := ioutil.WriteFile(scriptFile, []byte(script), 0644)
 	if err != nil {
 		return "", nil, err
 	}
@@ -124,7 +136,7 @@ func (r *RunParams) Run() error {
 		return err
 	}
 
-	shell, args, err := shellAndArgs(tempDir, r.Commands)
+	shell, args, err := shellAndArgs(tempDir, r.Commands, r.User)
 	if err != nil {
 		if err := os.RemoveAll(tempDir); err != nil {
 			logger.Warningf("failed to remove temporary directory: %v", err)

--- a/exec/exec_internal_test.go
+++ b/exec/exec_internal_test.go
@@ -1,0 +1,68 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package exec
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type execSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&execSuite{})
+
+func (*execSuite) TestShellAndArgsNoUserSpecified(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("non-windows only test")
+	}
+
+	dir := c.MkDir()
+	stat, err := os.Stat(dir)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stat.Mode().Perm(), gc.Equals, os.FileMode(0700))
+
+	cmd, args, err := shellAndArgs(dir, "env", "")
+	c.Assert(err, jc.ErrorIsNil)
+
+	scriptFile := filepath.Join(dir, "script.sh")
+
+	c.Assert(cmd, gc.Equals, "/bin/bash")
+	c.Assert(args, jc.DeepEquals, []string{scriptFile})
+}
+
+func (*execSuite) TestShellAndArgsAsUser(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("non-windows only test")
+	}
+
+	dir := c.MkDir()
+	stat, err := os.Stat(dir)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stat.Mode().Perm(), gc.Equals, os.FileMode(0700))
+
+	cmd, args, err := shellAndArgs(dir, "env", "ubuntu")
+	c.Assert(err, jc.ErrorIsNil)
+
+	scriptFile := filepath.Join(dir, "script.sh")
+
+	c.Assert(cmd, gc.Equals, "/bin/su")
+	command := "/bin/bash " + scriptFile
+	c.Assert(args, jc.DeepEquals, []string{"ubuntu", "-c", command})
+
+	// The directory is now readable by everyone.
+	stat, err = os.Stat(dir)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stat.Mode().Perm(), gc.Equals, os.FileMode(0755))
+	// And the file is world readable
+	stat, err = os.Stat(scriptFile)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stat.Mode().Perm(), gc.Equals, os.FileMode(0644))
+}

--- a/exec/exec_internal_test.go
+++ b/exec/exec_internal_test.go
@@ -55,7 +55,7 @@ func (*execSuite) TestShellAndArgsAsUser(c *gc.C) {
 
 	c.Assert(cmd, gc.Equals, "/bin/su")
 	command := "/bin/bash " + scriptFile
-	c.Assert(args, jc.DeepEquals, []string{"ubuntu", "-c", command})
+	c.Assert(args, jc.DeepEquals, []string{"ubuntu", "--login", "--command", command})
 
 	// The directory is now readable by everyone.
 	stat, err = os.Stat(dir)


### PR DESCRIPTION
This is important for juju as the juju agents run as root, but we don't always want to execute commands as root. In particular when a user executes 'juju run' for a machine as opposed to an agent, we want to run those commands as the "ubuntu" user.