### PR TITLE
Add monotonic Now()

### DIFF
--- a/clock/monotonic/monotonic.go
+++ b/clock/monotonic/monotonic.go
@@ -1,0 +1,22 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package monotonic
+
+import (
+	"time"
+	_ "unsafe"
+)
+
+//go:noescape
+//go:linkname nanotime runtime.nanotime
+func nanotime() int64
+
+// Now returns the current time in nanoseconds from a monotonic clock.
+//
+// The result is guaranteed to not jump due to NTP or other changes to
+// system time, which may jump forward or backwards. Instead, in response to
+// such changes, the clock frequency is adjusted slowly.
+func Now() time.Duration {
+	return time.Duration(nanotime())
+}

--- a/clock/monotonic/monotonic.s
+++ b/clock/monotonic/monotonic.s
@@ -1,0 +1,4 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// Deliberately empty - see https://github.com/golang/go/issues/15006

--- a/clock/monotonic/monotonic_test.go
+++ b/clock/monotonic/monotonic_test.go
@@ -1,0 +1,33 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package monotonic_test
+
+import (
+	"testing"
+	"time"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils/clock/monotonic"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}
+
+type MonotonicSuite struct {
+}
+
+var _ = gc.Suite(&MonotonicSuite{})
+
+func (s *MonotonicSuite) TestNow(c *gc.C) {
+	var prev time.Duration
+	for i := 0; i < 1000; i++ {
+		val := monotonic.Now()
+		if val < prev {
+			c.Fatal("now is less than previous value")
+		}
+		prev = val
+	}
+}


### PR DESCRIPTION
Provide a Now() function which provides a time in nanoseconds from a monotonic clock.