### PR TITLE
utils: drop gabriel-samfira/sys fork dependency

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -15,6 +15,7 @@ github.com/masterzen/xmlpath	git	13f4951698adc0fa9c1dda3e275d489a24201161	2014-0
 github.com/nu7hatch/gouuid	git	179d4d0c4d8d407a32af483c2354df1d2c91e6c3	2016-02-18t18:59:01Z
 golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:06:42Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
+golang.org/x/sys	git	7a6e5648d140666db5d920909e082ca00a87ba2c	2017-02-01T05:12:45Z
 golang.org/x/text	git	b01949dc0793a9af5e4cb3fce4d42999e76e8ca1	2016-05-25T23:07:23Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z

--- a/featureflag/flags_windows.go
+++ b/featureflag/flags_windows.go
@@ -7,7 +7,7 @@
 package featureflag
 
 import (
-	"github.com/gabriel-samfira/sys/windows/registry"
+	"golang.org/x/sys/windows/registry"
 )
 
 // SetFlagsFromRegistry populates the global set from the registry keys on

--- a/featureflag/flags_windows_test.go
+++ b/featureflag/flags_windows_test.go
@@ -4,7 +4,7 @@
 package featureflag_test
 
 import (
-	"github.com/gabriel-samfira/sys/windows/registry"
+	"golang.org/x/sys/windows/registry"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/series/series_windows.go
+++ b/series/series_windows.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/gabriel-samfira/sys/windows/registry"
+	"golang.org/x/sys/windows/registry"
 	"github.com/juju/errors"
 )
 

--- a/series/series_windows_test.go
+++ b/series/series_windows_test.go
@@ -7,7 +7,7 @@ package series_test
 import (
 	"fmt"
 
-	"github.com/gabriel-samfira/sys/windows/registry"
+	"golang.org/x/sys/windows/registry"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"


### PR DESCRIPTION
We're no longer using Go 1.2, so we can drop the fork.
Part of fixing https://bugs.launchpad.net/juju/+bug/1470820.