### PR TITLE
Adjust precedence used for juju apt proxy conf

### DIFF
--- a/packaging/commands/apt.go
+++ b/packaging/commands/apt.go
@@ -7,7 +7,7 @@ package commands
 const (
 	// AptConfFilePath is the full file path for the proxy settings that are
 	// written by cloud-init and the machine environ worker.
-	AptConfFilePath = "/etc/apt/apt.conf.d/42-juju-proxy-settings"
+	AptConfFilePath = "/etc/apt/apt.conf.d/95-juju-proxy-settings"
 
 	// the basic command for all dpkg calls:
 	dpkg = "dpkg"

--- a/packaging/config/apt_constants.go
+++ b/packaging/config/apt_constants.go
@@ -37,7 +37,7 @@ const (
 var (
 	// AptProxyConfigFile is the full file path for the proxy settings that are
 	// written by cloudinit and the machine environ worker.
-	AptProxyConfigFile = AptConfigDirectory + "/42-juju-proxy-settings"
+	AptProxyConfigFile = AptConfigDirectory + "/95-juju-proxy-settings"
 
 	// AptPreferenceTemplate is the template specific to an apt preference file.
 	AptPreferenceTemplate = template.Must(template.New("").Parse(`


### PR DESCRIPTION
Adjust the precedence used for the apt proxy conf file so that Juju's settings override any MAAS settings.