### PR TITLE
Add function to export proxy settings as systemd config

### DIFF
--- a/packaging/manager/testing/manager.go
+++ b/packaging/manager/testing/manager.go
@@ -71,7 +71,7 @@ func (pm *MockPackageManager) Cleanup() error {
 
 // GetProxySettings is defined on the PackageManager interface.
 func (pm *MockPackageManager) GetProxySettings() (proxy.Settings, error) {
-	return proxy.Settings{"http proxy", "https proxy", "ftp proxy", "no proxy"}, nil
+	return proxy.Settings{"http proxy", "https proxy", "ftp proxy", "no proxy", "auto no proxy"}, nil
 }
 
 // SetProxy is defined on the PackageManager interface.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -21,6 +21,7 @@ const (
 
 // Settings holds the values for the HTTP, HTTPS and FTP proxies as well as the
 // no_proxy value found by Detect Proxies.
+// AutoNoProxy is filled with addresses of controllers, we never want to proxy those
 type Settings struct {
 	Http        string
 	Https       string
@@ -64,7 +65,10 @@ func (s *Settings) AsScriptEnvironment() string {
 	addLine(https_proxy, s.Https)
 	addLine(ftp_proxy, s.Ftp)
 	addLine(no_proxy, s.FullNoProxy())
-	return strings.Join(lines, "\n")
+	if len(lines) == 0 {
+		return ""
+	}
+	return strings.Join(lines, "\n") + "\n"
 }
 
 // AsEnvironmentValues returns a slice of strings of the format "key=value"
@@ -96,7 +100,7 @@ DefaultEnvironment=`
 	for _, line := range lines {
 		rv += fmt.Sprintf(`"%s" `, line)
 	}
-	return rv
+	return rv + "\n"
 }
 
 // SetEnvironmentValues updates the process environment with the

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -84,6 +84,18 @@ func (s *Settings) AsEnvironmentValues() []string {
 	return lines
 }
 
+// AsSystemdEnvSettings returns a string in the format understood by systemd:
+// DefaultEnvironment="http_proxy=...." "HTTP_PROXY=..." ...
+func (s *Settings) AsSystemdDefaultEnv() string {
+	lines := s.AsEnvironmentValues()
+	rv := `[Manager]
+DefaultEnvironment=`
+	for _, line := range lines {
+		rv += fmt.Sprintf(`"%s" `, line)
+	}
+	return rv
+}
+
 // SetEnvironmentValues updates the process environment with the
 // proxy values stored in the settings object.  Both the lower-case
 // and upper-case variants are set.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -113,3 +113,13 @@ func (s *Settings) SetEnvironmentValues() {
 	setenv(ftp_proxy, s.Ftp)
 	setenv(no_proxy, s.NoProxy)
 }
+
+// AddNoProxyAddresses adds addresses to NoProxy list, usually for controllers
+func (s *Settings) AddNoProxyAddresses(newAddrs []string) {
+	addrs := strings.Split(s.NoProxy, ",")
+	if len(addrs) == 1 && addrs[0] == "" {
+		addrs = addrs[:0]
+	}
+	addrs = append(addrs, newAddrs...)
+	s.NoProxy = strings.Join(addrs, ",")
+}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -215,22 +215,21 @@ func (s *proxySuite) TestSetEnvironmentValues(c *gc.C) {
 	c.Assert(os.Getenv("NO_PROXY"), gc.Equals, "10.0.3.1,localhost")
 }
 
-func (s *proxySuite) TestAddNoProxyAddresses(c *gc.C) {
-	proxies := proxy.Settings{}
-
-	expectedFirst := []string{}
-	expectedSecond := []string{
-		"no_proxy=second",
-		"NO_PROXY=second",
+func (s *proxySuite) TestAutoNoProxy(c *gc.C) {
+	proxies := proxy.Settings{
+		NoProxy: "10.0.3.1,localhost",
 	}
-	expectedThird := []string{
-		"no_proxy=second,third,fourth",
-		"NO_PROXY=second,third,fourth",
+
+	expectedFirst := []string{
+		"no_proxy=10.0.3.1,localhost",
+		"NO_PROXY=10.0.3.1,localhost",
+	}
+	expectedSecond := []string{
+		"no_proxy=10.0.3.1,10.0.3.2,localhost",
+		"NO_PROXY=10.0.3.1,10.0.3.2,localhost",
 	}
 
 	c.Assert(proxies.AsEnvironmentValues(), gc.DeepEquals, expectedFirst)
-	proxies.AddNoProxyAddresses([]string{"second"})
+	proxies.AutoNoProxy = "10.0.3.1,10.0.3.2"
 	c.Assert(proxies.AsEnvironmentValues(), gc.DeepEquals, expectedSecond)
-	proxies.AddNoProxyAddresses([]string{"third", "fourth"})
-	c.Assert(proxies.AsEnvironmentValues(), gc.DeepEquals, expectedThird)
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -112,7 +112,8 @@ func (s *proxySuite) TestAsScriptEnvironmentOneValue(c *gc.C) {
 	}
 	expected := `
 export http_proxy=some-value
-export HTTP_PROXY=some-value`[1:]
+export HTTP_PROXY=some-value
+`[1:]
 	c.Assert(proxies.AsScriptEnvironment(), gc.Equals, expected)
 }
 
@@ -131,7 +132,8 @@ export HTTPS_PROXY=special
 export ftp_proxy=who uses this?
 export FTP_PROXY=who uses this?
 export no_proxy=10.0.3.1,localhost
-export NO_PROXY=10.0.3.1,localhost`[1:]
+export NO_PROXY=10.0.3.1,localhost
+`[1:]
 	c.Assert(proxies.AsScriptEnvironment(), gc.Equals, expected)
 }
 
@@ -178,8 +180,10 @@ func (s *proxySuite) TestAsSystemdDefaultEnv(c *gc.C) {
 		Ftp:     "who uses this?",
 		NoProxy: "10.0.3.1,localhost",
 	}
-	expected := `[Manager]
-DefaultEnvironment="http_proxy=some-value" "HTTP_PROXY=some-value" "https_proxy=special" "HTTPS_PROXY=special" "ftp_proxy=who uses this?" "FTP_PROXY=who uses this?" "no_proxy=10.0.3.1,localhost" "NO_PROXY=10.0.3.1,localhost" `
+	expected := `
+[Manager]
+DefaultEnvironment="http_proxy=some-value" "HTTP_PROXY=some-value" "https_proxy=special" "HTTPS_PROXY=special" "ftp_proxy=who uses this?" "FTP_PROXY=who uses this?" "no_proxy=10.0.3.1,localhost" "NO_PROXY=10.0.3.1,localhost" 
+`[1:]
 	c.Assert(proxies.AsSystemdDefaultEnv(), gc.DeepEquals, expected)
 }
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -171,6 +171,18 @@ func (s *proxySuite) TestAsEnvironmentValuesAllValue(c *gc.C) {
 	c.Assert(proxies.AsEnvironmentValues(), gc.DeepEquals, expected)
 }
 
+func (s *proxySuite) TestAsSystemdDefaultEnv(c *gc.C) {
+	proxies := proxy.Settings{
+		Http:    "some-value",
+		Https:   "special",
+		Ftp:     "who uses this?",
+		NoProxy: "10.0.3.1,localhost",
+	}
+	expected := `[Manager]
+DefaultEnvironment="http_proxy=some-value" "HTTP_PROXY=some-value" "https_proxy=special" "HTTPS_PROXY=special" "ftp_proxy=who uses this?" "FTP_PROXY=who uses this?" "no_proxy=10.0.3.1,localhost" "NO_PROXY=10.0.3.1,localhost" `
+	c.Assert(proxies.AsSystemdDefaultEnv(), gc.DeepEquals, expected)
+}
+
 func (s *proxySuite) TestSetEnvironmentValues(c *gc.C) {
 	s.PatchEnvironment("http_proxy", "initial")
 	s.PatchEnvironment("HTTP_PROXY", "initial")

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -214,3 +214,23 @@ func (s *proxySuite) TestSetEnvironmentValues(c *gc.C) {
 	c.Assert(os.Getenv("no_proxy"), gc.Equals, "10.0.3.1,localhost")
 	c.Assert(os.Getenv("NO_PROXY"), gc.Equals, "10.0.3.1,localhost")
 }
+
+func (s *proxySuite) TestAddNoProxyAddresses(c *gc.C) {
+	proxies := proxy.Settings{}
+
+	expectedFirst := []string{}
+	expectedSecond := []string{
+		"no_proxy=second",
+		"NO_PROXY=second",
+	}
+	expectedThird := []string{
+		"no_proxy=second,third,fourth",
+		"NO_PROXY=second,third,fourth",
+	}
+
+	c.Assert(proxies.AsEnvironmentValues(), gc.DeepEquals, expectedFirst)
+	proxies.AddNoProxyAddresses([]string{"second"})
+	c.Assert(proxies.AsEnvironmentValues(), gc.DeepEquals, expectedSecond)
+	proxies.AddNoProxyAddresses([]string{"third", "fourth"})
+	c.Assert(proxies.AsEnvironmentValues(), gc.DeepEquals, expectedThird)
+}


### PR DESCRIPTION
ProxySettings.AsSystemdDefaultEnv exports proxy settings in a form understandable by systemd.