### PR TITLE
add Setenv function

### DIFF
--- a/setenv.go
+++ b/setenv.go
@@ -1,0 +1,30 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package utils
+import (
+	"strings"
+)
+
+// Setenv sets an environment variable entry in the given env slice (as
+// returned by os.Environ or passed in exec.Cmd.Environ) to the given
+// value. The entry must be in the form "x=y" where x is the name of the
+// environment variable and y is its value.
+//
+// If a value isn't already present in the slice, the entry is appended.
+//
+// The new environ slice is returned.
+func Setenv(env []string, entry string) []string {
+	i := strings.Index(entry, "=")
+	if i == -1 {
+		panic("no = in environment entry")
+	}
+	prefix := entry[0 : i+1]
+	for i, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			env[i] = entry
+			return env
+		}
+	}
+	return append(env, entry)
+}

--- a/setenv_test.go
+++ b/setenv_test.go
@@ -1,0 +1,40 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package utils_test
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils"
+)
+
+type SetenvSuite struct{}
+
+var _ = gc.Suite(&SetenvSuite{})
+
+var setenvTests = []struct {
+	set    string
+	expect []string
+}{
+	{"foo=1", []string{"foo=1", "arble="}},
+	{"foo=", []string{"foo=", "arble="}},
+	{"arble=23", []string{"foo=bar", "arble=23"}},
+	{"zaphod=42", []string{"foo=bar", "arble=", "zaphod=42"}},
+}
+
+func (*SetenvSuite) TestSetenv(c *gc.C) {
+	env0 := []string{"foo=bar", "arble="}
+	for i, t := range setenvTests {
+		c.Logf("test %d", i)
+		env := make([]string, len(env0))
+		copy(env, env0)
+		env = utils.Setenv(env, t.set)
+		c.Check(env, gc.DeepEquals, t.expect)
+	}
+}
+
+func (*SetenvSuite) TestSetenvWithBadFormatPanics(c *gc.C) {
+	c.Assert(func() {
+		utils.Setenv(nil, "foo")
+	}, gc.PanicMatches, "no = in environment entry")
+}


### PR DESCRIPTION
This makes it easier to override environment variables
since just appending environment variables doesn't
work any more (and never did for non-Go programs).
See https://github.com/golang/go/issues/19877 for
background.