### PR TITLE
make Setenv ignore malformed entries rather than panic

### DIFF
--- a/setenv.go
+++ b/setenv.go
@@ -2,14 +2,16 @@
 // Licensed under the LGPLv3, see LICENCE file for details.
 
 package utils
+
 import (
 	"strings"
 )
 
 // Setenv sets an environment variable entry in the given env slice (as
 // returned by os.Environ or passed in exec.Cmd.Environ) to the given
-// value. The entry must be in the form "x=y" where x is the name of the
-// environment variable and y is its value.
+// value. The entry should be in the form "x=y" where x is the name of the
+// environment variable and y is its value; if not, env will be
+// returned unchanged.
 //
 // If a value isn't already present in the slice, the entry is appended.
 //
@@ -17,7 +19,7 @@ import (
 func Setenv(env []string, entry string) []string {
 	i := strings.Index(entry, "=")
 	if i == -1 {
-		panic("no = in environment entry")
+		return env
 	}
 	prefix := entry[0 : i+1]
 	for i, e := range env {

--- a/setenv_test.go
+++ b/setenv_test.go
@@ -2,6 +2,7 @@
 // Licensed under the LGPLv3, see LICENCE file for details.
 
 package utils_test
+
 import (
 	gc "gopkg.in/check.v1"
 
@@ -20,6 +21,7 @@ var setenvTests = []struct {
 	{"foo=", []string{"foo=", "arble="}},
 	{"arble=23", []string{"foo=bar", "arble=23"}},
 	{"zaphod=42", []string{"foo=bar", "arble=", "zaphod=42"}},
+	{"bar", []string{"foo=bar", "arble="}},
 }
 
 func (*SetenvSuite) TestSetenv(c *gc.C) {
@@ -31,10 +33,4 @@ func (*SetenvSuite) TestSetenv(c *gc.C) {
 		env = utils.Setenv(env, t.set)
 		c.Check(env, gc.DeepEquals, t.expect)
 	}
-}
-
-func (*SetenvSuite) TestSetenvWithBadFormatPanics(c *gc.C) {
-	c.Assert(func() {
-		utils.Setenv(nil, "foo")
-	}, gc.PanicMatches, "no = in environment entry")
 }


### PR DESCRIPTION
Responding to JAM's review on PR #273.