### PR TITLE
proxy: do not add extra newline

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -52,7 +52,7 @@ func DetectProxies() Settings {
 // that specifies exported key=value lines. There are two lines for each non-
 // empty proxy value, one lower-case and one upper-case.
 func (s *Settings) AsScriptEnvironment() string {
-	lines := []string{}
+	var lines []string
 	addLine := func(proxy, value string) {
 		if value != "" {
 			lines = append(
@@ -65,10 +65,7 @@ func (s *Settings) AsScriptEnvironment() string {
 	addLine(https_proxy, s.Https)
 	addLine(ftp_proxy, s.Ftp)
 	addLine(no_proxy, s.FullNoProxy())
-	if len(lines) == 0 {
-		return ""
-	}
-	return strings.Join(lines, "\n") + "\n"
+	return strings.Join(lines, "\n")
 }
 
 // AsEnvironmentValues returns a slice of strings of the format "key=value"

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -112,8 +112,7 @@ func (s *proxySuite) TestAsScriptEnvironmentOneValue(c *gc.C) {
 	}
 	expected := `
 export http_proxy=some-value
-export HTTP_PROXY=some-value
-`[1:]
+export HTTP_PROXY=some-value`[1:]
 	c.Assert(proxies.AsScriptEnvironment(), gc.Equals, expected)
 }
 
@@ -132,8 +131,7 @@ export HTTPS_PROXY=special
 export ftp_proxy=who uses this?
 export FTP_PROXY=who uses this?
 export no_proxy=10.0.3.1,localhost
-export NO_PROXY=10.0.3.1,localhost
-`[1:]
+export NO_PROXY=10.0.3.1,localhost`[1:]
 	c.Assert(proxies.AsScriptEnvironment(), gc.Equals, expected)
 }
 


### PR DESCRIPTION
PR #271 changed AsScriptEnvironment so that
it adds a trailing newline to the script lines.

Some juju tests failed as a result of this change, so revert
to the previous behaviour - the final newline isn't
needed.