### PR TITLE
ssh: host-key checking for crypto/ssh client

### DIFF
--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -203,14 +203,11 @@ func (certSuite) TestNewClientCertRSASize(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(value, gc.Not(gc.IsNil))
 
-		expected := []pkix.Extension{
-			{
-				Id:       cert.CertSubjAltName,
-				Value:    value,
-				Critical: false,
-			},
-		}
-		c.Assert(caCert.Extensions[4], jc.DeepEquals, expected[0])
+		c.Assert(caCert.Extensions[len(caCert.Extensions)-1], jc.DeepEquals, pkix.Extension{
+			Id:       cert.CertSubjAltName,
+			Value:    value,
+			Critical: false,
+		})
 		c.Assert(caCert.PublicKeyAlgorithm, gc.Equals, x509.RSA)
 		c.Assert(caCert.ExtKeyUsage[0], gc.Equals, x509.ExtKeyUsageClientAuth)
 		checkNotBefore(c, caCert, now)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -4,6 +4,7 @@ github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	89d547093c45e293599088cc63e805c6f1205dc0	2016-03-02T10:09:58Z
 github.com/juju/loggo	git	15901ae4de786d05edae84a27c93d3fbef66c91e	2016-08-04T22:15:26Z
+github.com/juju/mutex	git	59c26ee163447c5c57f63ff71610d433862013de	2016-06-17T01:09:07Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/testing	git	7177264a582e2c00d08277eaa91d88f8eb0fd869	2016-09-26T12:59:16Z
 github.com/juju/version	git	4ae6172c00626779a5a462c3e3d22fc0e889431a	2016-06-03T19:49:58Z
@@ -13,7 +14,7 @@ github.com/masterzen/simplexml	git	4572e39b1ab9fe03ee513ce6fc7e289e98482190	2016
 github.com/masterzen/winrm	git	7a535cd943fccaeed196718896beec3fb51aff41	2016-08-04T09:38:27Z
 github.com/masterzen/xmlpath	git	13f4951698adc0fa9c1dda3e275d489a24201161	2014-02-18T18:59:01Z
 github.com/nu7hatch/gouuid	git	179d4d0c4d8d407a32af483c2354df1d2c91e6c3	2016-02-18t18:59:01Z
-golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:06:42Z
+golang.org/x/crypto	git	96846453c37f0876340a66a47f3f75b1f3a6cd2d	2017-04-21T04:31:20Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 golang.org/x/sys	git	7a6e5648d140666db5d920909e082ca00a87ba2c	2017-02-01T05:12:45Z
 golang.org/x/text	git	b01949dc0793a9af5e4cb3fce4d42999e76e8ca1	2016-05-25T23:07:23Z

--- a/ssh/authorisedkeys.go
+++ b/ssh/authorisedkeys.go
@@ -167,13 +167,13 @@ func writeAuthorisedKeys(username string, keys []string) error {
 // We need a mutex because updates to the authorised keys file are done by
 // reading the contents, updating, and writing back out. So only one caller
 // at a time can use either Add, Delete, List.
-var mutex sync.Mutex
+var keysMutex sync.Mutex
 
 // AddKeys adds the specified ssh keys to the authorized_keys file for user.
 // Returns an error if there is an issue with *any* of the supplied keys.
 func AddKeys(user string, newKeys ...string) error {
-	mutex.Lock()
-	defer mutex.Unlock()
+	keysMutex.Lock()
+	defer keysMutex.Unlock()
 	existingKeys, err := readAuthorisedKeys(user)
 	if err != nil {
 		return err
@@ -211,8 +211,8 @@ func AddKeys(user string, newKeys ...string) error {
 // keyIds may be either key comments or fingerprints.
 // Returns an error if there is an issue with *any* of the keys to delete.
 func DeleteKeys(user string, keyIds ...string) error {
-	mutex.Lock()
-	defer mutex.Unlock()
+	keysMutex.Lock()
+	defer keysMutex.Unlock()
 	existingKeyData, err := readAuthorisedKeys(user)
 	if err != nil {
 		return err
@@ -261,8 +261,8 @@ func DeleteKeys(user string, keyIds ...string) error {
 // replacing any that are already there.
 // Returns an error if there is an issue with *any* of the supplied keys.
 func ReplaceKeys(user string, newKeys ...string) error {
-	mutex.Lock()
-	defer mutex.Unlock()
+	keysMutex.Lock()
+	defer keysMutex.Unlock()
 
 	existingKeyData, err := readAuthorisedKeys(user)
 	if err != nil {
@@ -280,8 +280,8 @@ func ReplaceKeys(user string, newKeys ...string) error {
 
 // ListKeys returns either the full keys or key comments from the authorized ssh keys file for user.
 func ListKeys(user string, mode ListMode) ([]string, error) {
-	mutex.Lock()
-	defer mutex.Unlock()
+	keysMutex.Lock()
+	defer keysMutex.Unlock()
 	keyData, err := readAuthorisedKeys(user)
 	if err != nil {
 		return nil, err

--- a/ssh/run_test.go
+++ b/ssh/run_test.go
@@ -66,7 +66,7 @@ func (s *ExecuteSSHCommandSuite) TestCaptureOutput(c *gc.C) {
 	c.Assert(response.Code, gc.Equals, 0)
 	c.Assert(string(response.Stdout), gc.Equals, "sudo apt-get update\nsudo apt-get upgrade\n")
 	c.Assert(string(response.Stderr), gc.Equals,
-		"-o StrictHostKeyChecking no -o PasswordAuthentication no -o ServerAliveInterval 30 hostname /bin/bash -s\n")
+		"-o PasswordAuthentication no -o ServerAliveInterval 30 hostname /bin/bash -s\n")
 }
 
 func (s *ExecuteSSHCommandSuite) TestIdentityFile(c *gc.C) {

--- a/ssh/ssh_gocrypto_test.go
+++ b/ssh/ssh_gocrypto_test.go
@@ -4,13 +4,18 @@
 package ssh_test
 
 import (
+	"bytes"
+	"crypto/rand"
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sync"
 
 	"github.com/juju/testing"
@@ -32,18 +37,16 @@ type sshServer struct {
 	client   *cryptossh.Client
 }
 
-func newServer(c *gc.C) *sshServer {
+func newServer(c *gc.C, serverConfig cryptossh.ServerConfig) (*sshServer, cryptossh.PublicKey) {
 	private, _, err := ssh.GenerateKey("test-server")
 	c.Assert(err, jc.ErrorIsNil)
 	key, err := cryptossh.ParsePrivateKey([]byte(private))
 	c.Assert(err, jc.ErrorIsNil)
-	server := &sshServer{
-		cfg: &cryptossh.ServerConfig{},
-	}
+	server := &sshServer{cfg: &serverConfig}
 	server.cfg.AddHostKey(key)
 	server.listener, err = net.Listen("tcp", "127.0.0.1:0")
 	c.Assert(err, jc.ErrorIsNil)
-	return server
+	return server, key.PublicKey()
 }
 
 func (s *sshServer) run(c *gc.C) {
@@ -86,9 +89,19 @@ func (s *sshServer) run(c *gc.C) {
 	}
 }
 
+func newClient(c *gc.C) (*ssh.GoCryptoClient, cryptossh.PublicKey) {
+	private, _, err := ssh.GenerateKey("test-client")
+	c.Assert(err, jc.ErrorIsNil)
+	key, err := cryptossh.ParsePrivateKey([]byte(private))
+	client, err := ssh.NewGoCryptoClient(key)
+	c.Assert(err, jc.ErrorIsNil)
+	return client, key.PublicKey()
+}
+
 type SSHGoCryptoCommandSuite struct {
 	testing.IsolationSuite
-	client ssh.Client
+	client         ssh.Client
+	knownHostsFile string
 }
 
 var _ = gc.Suite(&SSHGoCryptoCommandSuite{})
@@ -100,6 +113,9 @@ func (s *SSHGoCryptoCommandSuite) SetUpTest(c *gc.C) {
 	client, err := ssh.NewGoCryptoClient()
 	c.Assert(err, jc.ErrorIsNil)
 	s.client = client
+
+	s.knownHostsFile = filepath.Join(c.MkDir(), "known_hosts")
+	ssh.SetGoCryptoKnownHostsFile(s.knownHostsFile)
 }
 
 func (s *SSHGoCryptoCommandSuite) TestNewGoCryptoClient(c *gc.C) {
@@ -133,18 +149,16 @@ func (s *SSHGoCryptoCommandSuite) TestClientNoKeys(c *gc.C) {
 }
 
 func (s *SSHGoCryptoCommandSuite) TestCommand(c *gc.C) {
-	private, _, err := ssh.GenerateKey("test-server")
-	c.Assert(err, jc.ErrorIsNil)
-	key, err := cryptossh.ParsePrivateKey([]byte(private))
-	client, err := ssh.NewGoCryptoClient(key)
-	c.Assert(err, jc.ErrorIsNil)
-	server := newServer(c)
+	client, clientKey := newClient(c)
+	server, serverKey := newServer(c, cryptossh.ServerConfig{})
+	serverPort := server.listener.Addr().(*net.TCPAddr).Port
 	var opts ssh.Options
-	opts.SetPort(server.listener.Addr().(*net.TCPAddr).Port)
+	opts.SetPort(serverPort)
+	opts.SetStrictHostKeyChecking(ssh.StrictHostChecksNo)
 	cmd := client.Command("127.0.0.1", testCommand, &opts)
 	checkedKey := false
 	server.cfg.PublicKeyCallback = func(conn cryptossh.ConnMetadata, pubkey cryptossh.PublicKey) (*cryptossh.Permissions, error) {
-		c.Check(pubkey, gc.DeepEquals, key.PublicKey())
+		c.Check(pubkey, gc.DeepEquals, clientKey)
 		checkedKey = true
 		return nil, nil
 	}
@@ -153,6 +167,14 @@ func (s *SSHGoCryptoCommandSuite) TestCommand(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, "abc value\n")
 	c.Assert(checkedKey, jc.IsTrue)
+
+	knownHosts, err := ioutil.ReadFile(s.knownHostsFile)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(knownHosts), gc.Equals, fmt.Sprintf(
+		"[127.0.0.1]:%d %s",
+		serverPort,
+		cryptossh.MarshalAuthorizedKey(serverKey)),
+	)
 }
 
 func (s *SSHGoCryptoCommandSuite) TestCopy(c *gc.C) {
@@ -172,12 +194,8 @@ func (s *SSHGoCryptoCommandSuite) TestProxyCommand(c *gc.C) {
 	err = ioutil.WriteFile(netcat, []byte("#!/bin/sh\necho $0 \"$@\" > $0.args && exec "+realNetcat+" \"$@\""), 0755)
 	c.Assert(err, jc.ErrorIsNil)
 
-	private, _, err := ssh.GenerateKey("test-server")
-	c.Assert(err, jc.ErrorIsNil)
-	key, err := cryptossh.ParsePrivateKey([]byte(private))
-	client, err := ssh.NewGoCryptoClient(key)
-	c.Assert(err, jc.ErrorIsNil)
-	server := newServer(c)
+	client, _ := newClient(c)
+	server, _ := newServer(c, cryptossh.ServerConfig{})
 	var opts ssh.Options
 	port := server.listener.Addr().(*net.TCPAddr).Port
 	opts.SetProxyCommand(netcat, "-q0", "%h", "%p")
@@ -194,4 +212,215 @@ func (s *SSHGoCryptoCommandSuite) TestProxyCommand(c *gc.C) {
 	data, err := ioutil.ReadFile(netcat + ".args")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, fmt.Sprintf("%s -q0 127.0.0.1 %v\n", netcat, port))
+}
+
+func (s *SSHGoCryptoCommandSuite) TestStrictHostChecksYes(c *gc.C) {
+	server, _ := newServer(c, cryptossh.ServerConfig{NoClientAuth: true})
+	serverPort := server.listener.Addr().(*net.TCPAddr).Port
+	go server.run(c)
+
+	var opts ssh.Options
+	opts.SetPort(serverPort)
+	opts.SetStrictHostKeyChecking(ssh.StrictHostChecksYes)
+	client, _ := newClient(c)
+	cmd := client.Command("127.0.0.1", testCommand, &opts)
+	_, err := cmd.Output()
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(
+		"ssh: handshake failed: no ssh-rsa host key is known for 127.0.0.1:%d and you have requested strict checking",
+		serverPort,
+	))
+	_, err = os.Stat(s.knownHostsFile)
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+}
+
+func (s *SSHGoCryptoCommandSuite) TestStrictHostChecksAskNonTerminal(c *gc.C) {
+	server, _ := newServer(c, cryptossh.ServerConfig{NoClientAuth: true})
+	serverPort := server.listener.Addr().(*net.TCPAddr).Port
+	go server.run(c)
+
+	var opts ssh.Options
+	opts.SetPort(serverPort)
+	opts.SetStrictHostKeyChecking(ssh.StrictHostChecksAsk)
+	client, _ := newClient(c)
+	cmd := client.Command("127.0.0.1", testCommand, &opts)
+	_, err := cmd.Output()
+	c.Assert(err, gc.ErrorMatches, "ssh: handshake failed: not running in a terminal, cannot prompt for verification")
+	_, err = os.Stat(s.knownHostsFile)
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+}
+
+func (s *SSHGoCryptoCommandSuite) TestStrictHostChecksAskTerminalYes(c *gc.C) {
+	var readLineWriter mockReadLineWriter
+	ssh.PatchTerminal(&s.CleanupSuite, &readLineWriter)
+	readLineWriter.addLine("")
+	readLineWriter.addLine("yes")
+
+	server, serverKey := newServer(c, cryptossh.ServerConfig{NoClientAuth: true})
+	serverPort := server.listener.Addr().(*net.TCPAddr).Port
+	go server.run(c)
+
+	var opts ssh.Options
+	opts.SetPort(serverPort)
+	opts.SetStrictHostKeyChecking(ssh.StrictHostChecksAsk)
+	client, _ := newClient(c)
+	cmd := client.Command("127.0.0.1", testCommand, &opts)
+	_, err := cmd.Output()
+	c.Assert(err, jc.ErrorIsNil)
+
+	knownHosts, err := ioutil.ReadFile(s.knownHostsFile)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(knownHosts), gc.Equals, fmt.Sprintf(
+		"[127.0.0.1]:%d %s",
+		serverPort,
+		cryptossh.MarshalAuthorizedKey(serverKey),
+	))
+
+	c.Assert(readLineWriter.written.String(), gc.Equals, fmt.Sprintf(`
+The authenticity of host '127.0.0.1:%[1]d (127.0.0.1:%[1]d)' can't be established.
+ssh-rsa key fingerprint is %[2]s.
+Are you sure you want to continue connecting (yes/no)? Please type 'yes' or 'no': `[1:],
+		serverPort, cryptossh.FingerprintSHA256(serverKey)))
+}
+
+func (s *SSHGoCryptoCommandSuite) TestStrictHostChecksAskTerminalNo(c *gc.C) {
+	var readLineWriter mockReadLineWriter
+	ssh.PatchTerminal(&s.CleanupSuite, &readLineWriter)
+	readLineWriter.addLine("no")
+
+	server, serverKey := newServer(c, cryptossh.ServerConfig{NoClientAuth: true})
+	serverPort := server.listener.Addr().(*net.TCPAddr).Port
+	go server.run(c)
+
+	var opts ssh.Options
+	opts.SetPort(serverPort)
+	opts.SetStrictHostKeyChecking(ssh.StrictHostChecksAsk)
+	client, _ := newClient(c)
+	cmd := client.Command("127.0.0.1", testCommand, &opts)
+	_, err := cmd.Output()
+	c.Assert(err, gc.ErrorMatches, "ssh: handshake failed: Host key verification failed.")
+
+	_, err = os.Stat(s.knownHostsFile)
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+
+	c.Assert(readLineWriter.written.String(), gc.Equals, fmt.Sprintf(`
+The authenticity of host '127.0.0.1:%[1]d (127.0.0.1:%[1]d)' can't be established.
+ssh-rsa key fingerprint is %[2]s.
+Are you sure you want to continue connecting (yes/no)? `[1:],
+		serverPort, cryptossh.FingerprintSHA256(serverKey)))
+}
+
+func (s *SSHGoCryptoCommandSuite) TestStrictHostChecksNoMismatch(c *gc.C) {
+	var readLineWriter mockReadLineWriter
+	ssh.PatchTerminal(&s.CleanupSuite, &readLineWriter)
+
+	server, serverKey := newServer(c, cryptossh.ServerConfig{NoClientAuth: true})
+	serverPort := server.listener.Addr().(*net.TCPAddr).Port
+	go server.run(c)
+
+	// Write a mismatching key to the known_hosts file. Even with
+	// StrictHostChecksNo, we should be verifying against an existing
+	// host key.
+	alternativeRSAKey, err := generateRSAKey(rand.Reader)
+	c.Assert(err, jc.ErrorIsNil)
+	alternativePublicKey, err := cryptossh.NewPublicKey(alternativeRSAKey.Public())
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(s.knownHostsFile, []byte(fmt.Sprintf(
+		"[127.0.0.1]:%d %s",
+		serverPort,
+		cryptossh.MarshalAuthorizedKey(alternativePublicKey),
+	)), 0600)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var opts ssh.Options
+	opts.SetPort(serverPort)
+	opts.SetStrictHostKeyChecking(ssh.StrictHostChecksNo)
+	client, _ := newClient(c)
+	cmd := client.Command("127.0.0.1", testCommand, &opts)
+	_, err = cmd.Output()
+	c.Assert(err, gc.ErrorMatches, "ssh: handshake failed: knownhosts: key mismatch")
+
+	c.Assert(readLineWriter.written.String(), gc.Matches, fmt.Sprintf(`
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
+Someone could be eavesdropping on you right now \(man-in-the-middle attack\)!
+It is also possible that a host key has just been changed.
+The fingerprint for the ssh-rsa key sent by the remote host is
+%s.
+Please contact your system administrator.
+Add correct host key in .*/known_hosts to get rid of this message.
+Offending ssh-rsa key in .*/known_hosts:1
+`[1:], regexp.QuoteMeta(cryptossh.FingerprintSHA256(serverKey))))
+}
+
+func (s *SSHGoCryptoCommandSuite) TestStrictHostChecksDifferentKeyTypes(c *gc.C) {
+	var readLineWriter mockReadLineWriter
+	ssh.PatchTerminal(&s.CleanupSuite, &readLineWriter)
+
+	server, serverKey := newServer(c, cryptossh.ServerConfig{NoClientAuth: true})
+	serverPort := server.listener.Addr().(*net.TCPAddr).Port
+	go server.run(c)
+
+	// Write a mismatching key to the known_hosts file with a different
+	// key type. Even with StrictHostChecksNo, we should be verifying
+	// against an existing host key.
+	dsaKey, err := generateDSAKey(rand.Reader)
+	c.Assert(err, jc.ErrorIsNil)
+	alternativePublicKey, err := cryptossh.NewPublicKey(&dsaKey.PublicKey)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(s.knownHostsFile, []byte(fmt.Sprintf(
+		"[127.0.0.1]:%d %s",
+		serverPort,
+		cryptossh.MarshalAuthorizedKey(alternativePublicKey),
+	)), 0600)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var opts ssh.Options
+	opts.SetPort(serverPort)
+	opts.SetStrictHostKeyChecking(ssh.StrictHostChecksNo)
+	client, _ := newClient(c)
+	cmd := client.Command("127.0.0.1", testCommand, &opts)
+	_, err = cmd.Output()
+	c.Assert(err, gc.ErrorMatches, "ssh: handshake failed: knownhosts: key mismatch")
+
+	c.Assert(readLineWriter.written.String(), gc.Matches, fmt.Sprintf(`
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
+Someone could be eavesdropping on you right now \(man-in-the-middle attack\)!
+It is also possible that a host key has just been changed.
+The fingerprint for the ssh-rsa key sent by the remote host is
+%s.
+Please contact your system administrator.
+Add correct host key in .*/known_hosts to get rid of this message.
+Host was previously using different host key algorithms:
+ - ssh-dss key in .*/known_hosts:1
+`[1:], regexp.QuoteMeta(cryptossh.FingerprintSHA256(serverKey))))
+}
+
+type mockReadLineWriter struct {
+	testing.Stub
+	lines   []string
+	written bytes.Buffer
+}
+
+func (m *mockReadLineWriter) addLine(line string) {
+	m.lines = append(m.lines, line)
+}
+
+func (m *mockReadLineWriter) ReadLine() (string, error) {
+	m.MethodCall(m, "ReadLine")
+	if len(m.lines) == 0 {
+		return "", io.EOF
+	}
+	line := m.lines[0]
+	m.lines = m.lines[1:]
+	return line, nil
+}
+
+func (m *mockReadLineWriter) Write(data []byte) (int, error) {
+	m.MethodCall(m, "Write", data)
+	return m.written.Write(data)
 }

--- a/ssh/ssh_openssh.go
+++ b/ssh/ssh_openssh.go
@@ -103,6 +103,9 @@ func opensshOptions(options *Options, commandKind opensshCommandKind) []string {
 	if options.knownHostsFile != "" {
 		args = append(args, "-o", "UserKnownHostsFile "+utils.CommandString(options.knownHostsFile))
 	}
+	if len(options.hostKeyAlgorithms) > 0 {
+		args = append(args, "-o", "HostKeyAlgorithms "+utils.CommandString(strings.Join(options.hostKeyAlgorithms, ",")))
+	}
 	identities := append([]string{}, options.identities...)
 	if pk := PrivateKeyFiles(); len(pk) > 0 {
 		// Add client keys as implicit identities


### PR DESCRIPTION
We introduce a host-key checker that mimics
the behaviour of the OpenSSH client. The
default "StrictHostKeyChecking" behaviour
is now for the crypto/ssh client to ask
(if a terminal is available, else fail),
and to leave off the option for openssh
to defer the decision to the openssh client
code.

We also make the host key algorithms
configurable. This will be used in a Juju
PR to limit which host key algorithms are
acceptable.

Note: this PR requires the builders to be
updated to Go 1.8 before it can land, as
the newer golang.org/x/crypto revision
uses the standard library context package.