### PR TITLE
call Sync() before Close() 

### DIFF
--- a/file.go
+++ b/file.go
@@ -125,10 +125,15 @@ func AtomicWriteFileAndChange(filename string, contents []byte, change func(*os.
 	if _, err := f.Write(contents); err != nil {
 		return fmt.Errorf("cannot write %q contents: %v", filename, err)
 	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
 	if err := change(f); err != nil {
 		return err
 	}
-	f.Close()
 	if err := ReplaceFile(f.Name(), filename); err != nil {
 		return fmt.Errorf("cannot replace %q with %q: %v", f.Name(), filename, err)
 	}

--- a/file.go
+++ b/file.go
@@ -106,7 +106,7 @@ func CopyFile(dest, source string) error {
 // AtomicWriteFileAndChange atomically writes the filename with the
 // given contents and calls the given function after the contents were
 // written, but before the file is renamed.
-func AtomicWriteFileAndChange(filename string, contents []byte, change func(*os.File) error) (err error) {
+func AtomicWriteFileAndChange(filename string, contents []byte, change func(string) error) (err error) {
 	dir, file := filepath.Split(filename)
 	f, err := ioutil.TempFile(dir, file)
 	if err != nil {
@@ -131,7 +131,7 @@ func AtomicWriteFileAndChange(filename string, contents []byte, change func(*os.
 	if err := f.Close(); err != nil {
 		return err
 	}
-	if err := change(f); err != nil {
+	if err := change(f.Name()); err != nil {
 		return err
 	}
 	if err := ReplaceFile(f.Name(), filename); err != nil {
@@ -144,9 +144,9 @@ func AtomicWriteFileAndChange(filename string, contents []byte, change func(*os.
 // contents and permissions, replacing any existing file at the same
 // path.
 func AtomicWriteFile(filename string, contents []byte, perms os.FileMode) (err error) {
-	return AtomicWriteFileAndChange(filename, contents, func(f *os.File) error {
+	return AtomicWriteFileAndChange(filename, contents, func(f string) error {
 		// FileMod.Chmod() is not implemented on Windows, however, os.Chmod() is
-		if err := os.Chmod(f.Name(), perms); err != nil {
+		if err := os.Chmod(f, perms); err != nil {
 			return fmt.Errorf("cannot set permissions: %v", err)
 		}
 		return nil

--- a/file_test.go
+++ b/file_test.go
@@ -105,9 +105,9 @@ var atomicWriteFileTests = []struct {
 }, {
 	summary: "atomic file write and change",
 	change: func(filename string, contents []byte) error {
-		chmodChange := func(f *os.File) error {
+		chmodChange := func(f string) error {
 			// FileMod.Chmod() is not implemented on Windows, however, os.Chmod() is
-			return os.Chmod(f.Name(), 0700)
+			return os.Chmod(f, 0700)
 		}
 		return utils.AtomicWriteFileAndChange(filename, contents, chmodChange)
 	},
@@ -117,7 +117,7 @@ var atomicWriteFileTests = []struct {
 }, {
 	summary: "atomic file write empty contents",
 	change: func(filename string, contents []byte) error {
-		nopChange := func(*os.File) error {
+		nopChange := func(string) error {
 			return nil
 		}
 		return utils.AtomicWriteFileAndChange(filename, contents, nopChange)
@@ -125,7 +125,7 @@ var atomicWriteFileTests = []struct {
 }, {
 	summary: "atomic file write and failing change func",
 	change: func(filename string, contents []byte) error {
-		errChange := func(*os.File) error {
+		errChange := func(string) error {
 			return fmt.Errorf("pow!")
 		}
 		return utils.AtomicWriteFileAndChange(filename, contents, errChange)

--- a/tar/tar.go
+++ b/tar/tar.go
@@ -155,6 +155,12 @@ func createAndFill(filePath string, mode int64, content io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("cannot set proper mode on file %q: %v", filePath, err)
 	}
+	if err := fh.Sync(); err != nil {
+		return fmt.Errorf("failed to sync contents of file %v: %v", filePath, err)
+	}
+	if err := fh.Close(); err != nil {
+		return fmt.Errorf("failed to close file %v: %v", filePath, err)
+	}
 	return nil
 }
 

--- a/yaml.go
+++ b/yaml.go
@@ -31,6 +31,12 @@ func WriteYaml(path string, obj interface{}) error {
 		os.Remove(tmp) // don't leak half written files on disk
 		return errors.Trace(err)
 	}
+
+	if err := f.Sync(); err != nil {
+		f.Close()      // don't leak file handle
+		os.Remove(tmp) // don't leak half written files on disk
+		return errors.Trace(err)
+	}
 	// Explicitly close the file before moving it. This is needed on Windows
 	// where the OS will not allow us to move a file that still has an open
 	// file handle. Must check the error on close because filesystems can delay

--- a/zip/zip.go
+++ b/zip/zip.go
@@ -142,7 +142,19 @@ func (x extractor) writeFile(targetPath string, zipFile *zip.File, modePerm os.F
 		return err
 	}
 	defer writer.Close()
-	return copyTo(writer, zipFile)
+
+	if err := copyTo(writer, zipFile); err != nil {
+		return err
+	}
+
+	if err := writer.Sync(); err != nil {
+		return err
+	}
+
+	if err := writer.Close(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (x extractor) writeSymlink(targetPath string, zipFile *zip.File) error {


### PR DESCRIPTION
On windows, disk cache and buffers are enabled by default. In the event of a power failure any file that has not yet flushed its contents to disk will become corupt. This leads to state files and agent configs being filled with garbage data.

fixes bug: https://bugs.launchpad.net/juju/+bug/1691193