### PR TITLE
Add optional pause time the limiter will wait for attempting an Acquire

### DIFF
--- a/limiter_test.go
+++ b/limiter_test.go
@@ -23,19 +23,19 @@ type limiterSuite struct {
 var _ = gc.Suite(&limiterSuite{})
 
 func (*limiterSuite) TestAcquireUntilFull(c *gc.C) {
-	l := utils.NewLimiter(2)
+	l := utils.NewLimiter(2, 0, nil)
 	c.Check(l.Acquire(), jc.IsTrue)
 	c.Check(l.Acquire(), jc.IsTrue)
 	c.Check(l.Acquire(), jc.IsFalse)
 }
 
 func (*limiterSuite) TestBadRelease(c *gc.C) {
-	l := utils.NewLimiter(2)
+	l := utils.NewLimiter(2, 0, nil)
 	c.Check(l.Release(), gc.ErrorMatches, "Release without an associated Acquire")
 }
 
 func (*limiterSuite) TestAcquireAndRelease(c *gc.C) {
-	l := utils.NewLimiter(2)
+	l := utils.NewLimiter(2, 0, nil)
 	c.Check(l.Acquire(), jc.IsTrue)
 	c.Check(l.Acquire(), jc.IsTrue)
 	c.Check(l.Acquire(), jc.IsFalse)
@@ -47,7 +47,7 @@ func (*limiterSuite) TestAcquireAndRelease(c *gc.C) {
 }
 
 func (*limiterSuite) TestAcquireWaitBlocksUntilRelease(c *gc.C) {
-	l := utils.NewLimiter(2)
+	l := utils.NewLimiter(2, 0, nil)
 	calls := make([]string, 0, 10)
 	start := make(chan bool, 0)
 	waiting := make(chan bool, 0)
@@ -78,4 +78,32 @@ func (*limiterSuite) TestAcquireWaitBlocksUntilRelease(c *gc.C) {
 		c.Fatalf("timed out waiting for 'done' to trigger")
 	}
 	c.Check(calls, gc.DeepEquals, []string{"true", "true", "false", "waited", "false"})
+}
+
+func (*limiterSuite) TestAcquirePauses(c *gc.C) {
+	clk := testing.NewClock(time.Time{})
+	l := utils.NewLimiter(2, 10*time.Millisecond, clk)
+	acquired := make(chan bool)
+	go func() {
+		acquired <- l.Acquire()
+	}()
+
+	// Pause time not exceeded, acquire should not happen.
+	select {
+	case <-acquired:
+		c.Fail()
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Acquire should happen any time up to the maximum pause time.
+	gotAcquired := false
+	for i := 0; i < 10 && !gotAcquired; i++ {
+		clk.Advance(time.Millisecond)
+		select {
+		case <-acquired:
+			gotAcquired = true
+		default:
+		}
+	}
+	c.Assert(gotAcquired, jc.IsTrue)
 }


### PR DESCRIPTION
A Limiter can be created such that it pauses a random time, up to a set maximum, before attempting an Acquire operation.