### PR TITLE
return early when deadline already passed in ContextWithDeadline

### DIFF
--- a/context.go
+++ b/context.go
@@ -88,6 +88,7 @@ func ContextWithDeadline(parent context.Context, clk clock.Clock, deadline time.
 	if d <= 0 {
 		// deadline has already passed
 		ctx.cancel(context.DeadlineExceeded)
+		return ctx, func() {}
 	}
 	ctx.timer = clk.NewTimer(d)
 	go func() {


### PR DESCRIPTION
This doesn't make any semantic difference, but is
slightly more efficient.