### PR TITLE
Keep 1.6 compatibility with context

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,10 +1,11 @@
 package utils
 
 import (
-	"context"
 	"fmt"
 	"sync"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"github.com/juju/utils/clock"
 )

--- a/context_test.go
+++ b/context_test.go
@@ -1,9 +1,10 @@
 package utils_test
 
 import (
-	"context"
 	"fmt"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"


### PR DESCRIPTION
Use the x/net/context library instead of the builtin one, to keep compatibilty with go1.6