### PR TITLE
Add GetIPv6Address function

### DIFF
--- a/network.go
+++ b/network.go
@@ -29,6 +29,23 @@ func GetIPv4Address(addresses []net.Addr) (string, error) {
 	return "", fmt.Errorf("no addresses match")
 }
 
+// GetIPv6Address iterates through the addresses expecting the format from
+// func (ifi *net.Interface) Addrs() ([]net.Addr, error) and returns the first
+// non-link local address.
+func GetIPv6Address(addresses []net.Addr) (string, error) {
+	_, llNet, _ := net.ParseCIDR("fe80::/10")
+	for _, addr := range addresses {
+		ip, _, err := net.ParseCIDR(addr.String())
+		if err != nil {
+			return "", err
+		}
+		if ip.To4() == nil && !llNet.Contains(ip) {
+			return ip.String(), nil
+		}
+	}
+	return "", fmt.Errorf("no addresses match")
+}
+
 // GetAddressForInterface looks for the network interface
 // and returns the IPv4 address from the possible addresses.
 func GetAddressForInterface(interfaceName string) (string, error) {
@@ -43,4 +60,24 @@ func GetAddressForInterface(interfaceName string) (string, error) {
 		return "", err
 	}
 	return GetIPv4Address(addrs)
+}
+
+// GetV4OrV6AddressForInterface looks for the network interface
+// and returns preferably the IPv4 address, and if it doesn't
+// exists then IPv6 address.
+func GetV4OrV6AddressForInterface(interfaceName string) (string, error) {
+	iface, err := net.InterfaceByName(interfaceName)
+	if err != nil {
+		logger.Errorf("cannot find network interface %q: %v", interfaceName, err)
+		return "", err
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		logger.Errorf("cannot get addresses for network interface %q: %v", interfaceName, err)
+		return "", err
+	}
+	if ip, err := GetIPv4Address(addrs); err == nil {
+		return ip, nil
+	}
+	return GetIPv6Address(addrs)
 }

--- a/network_test.go
+++ b/network_test.go
@@ -67,11 +67,61 @@ func (*networkSuite) TestGetIPv4Address(c *gc.C) {
 	}} {
 		ip, err := utils.GetIPv4Address(test.addresses)
 		if test.errorString == "" {
-			c.Assert(err, gc.IsNil)
-			c.Assert(ip, gc.Equals, test.expected)
+			c.Check(err, gc.IsNil)
+			c.Check(ip, gc.Equals, test.expected)
 		} else {
-			c.Assert(err, gc.ErrorMatches, test.errorString)
-			c.Assert(ip, gc.Equals, "")
+			c.Check(err, gc.ErrorMatches, test.errorString)
+			c.Check(ip, gc.Equals, "")
+		}
+	}
+}
+
+func (*networkSuite) TestGetIPv6Address(c *gc.C) {
+	for _, test := range []struct {
+		addresses   []net.Addr
+		expected    string
+		errorString string
+	}{{
+		addresses: makeAddresses(
+			"complete",
+			"nonsense"),
+		errorString: "invalid CIDR address: complete",
+	}, {
+		addresses: makeAddresses(
+			"fe80::90cf:9dff:fe6e:ece/64",
+		),
+		errorString: "no addresses match",
+	}, {
+		addresses: makeAddresses(
+			"fe80::90cf:9dff:fe6e:ece/64",
+			"10.0.3.1/24",
+		),
+		errorString: "no addresses match",
+	}, {
+		addresses: makeAddresses(
+			"10.0.3.1/24",
+		),
+		errorString: "no addresses match",
+	}, {
+		addresses: makeAddresses(
+			"10.0.3.1/24",
+			"2001:db8::90cf:9dff:fe6e:ece/64",
+		),
+		expected: "2001:db8::90cf:9dff:fe6e:ece",
+	}, {
+		addresses: makeAddresses(
+			"2001:db8::90cf:9dff:fe6e:ece/64",
+			"10.0.3.1/24",
+		),
+		expected: "2001:db8::90cf:9dff:fe6e:ece",
+	}} {
+		ip, err := utils.GetIPv6Address(test.addresses)
+		if test.errorString == "" {
+			c.Check(err, gc.IsNil)
+			c.Check(ip, gc.Equals, test.expected)
+		} else {
+			c.Check(err, gc.ErrorMatches, test.errorString)
+			c.Check(ip, gc.Equals, "")
 		}
 	}
 }


### PR DESCRIPTION
Add functions to get IPv6 address of an interface and to get IPv4 (preffered) or IPv6 (fallback) of an interface, to be used by juju LXD provider. 