### PR TITLE
series: don't consider pre-release series LTS

### DIFF
--- a/series/supportedseries_linux_test.go
+++ b/series/supportedseries_linux_test.go
@@ -63,6 +63,7 @@ func (s *supportedSeriesSuite) TestUpdateSeriesVersions(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	checkSeries()
 
+	expectedSeries = append([]string{"ornery"}, expectedSeries...)
 	expectedSeries = append(expectedSeries, "trusty")
 	series.UpdateSeriesVersions()
 	checkSeries()
@@ -106,4 +107,5 @@ const distInfoData = `version,codename,series,created,release,eol,eol-server
 
 const distInfoData2 = distInfoData + `
 14.04 LTS,Trusty Tahr,trusty,2013-10-17,2014-04-17,2019-04-17
+94.04 LTS,Ornery Omega,ornery,2094-10-17,2094-04-17,2099-04-17
 `


### PR DESCRIPTION
If a series says LTS, but is pre-release, don't
record it as LTS. This is a bit hackish, but
stops us from selecting it as a default series.