### PR TITLE
debugstatus: add context to checker

### DIFF
--- a/debugstatus/handler.go
+++ b/debugstatus/handler.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/errgo.v1"
 
 	pprof "github.com/juju/httpprof"
+	"golang.org/x/net/context"
 	"gopkg.in/httprequest.v1"
 )
 
@@ -28,7 +29,7 @@ type Handler struct {
 	// system. It should return a map as returned from the
 	// Check function. If this is nil, an empty result will
 	// always be returned from /debug/status.
-	Check func() map[string]CheckResult
+	Check func(context.Context) map[string]CheckResult
 
 	// Version should hold the current version
 	// of the binary running the server, served
@@ -59,11 +60,11 @@ type DebugStatusRequest struct {
 }
 
 // DebugStatus returns the current status of the server.
-func (h *Handler) DebugStatus(*DebugStatusRequest) (map[string]CheckResult, error) {
+func (h *Handler) DebugStatus(p httprequest.Params, _ *DebugStatusRequest) (map[string]CheckResult, error) {
 	if h.Check == nil {
 		return map[string]CheckResult{}, nil
 	}
-	return h.Check(), nil
+	return h.Check(p.Context), nil
 }
 
 // DebugInfoRequest describes the /debug/info endpoint.

--- a/debugstatus/handler_test.go
+++ b/debugstatus/handler_test.go
@@ -65,8 +65,8 @@ func newHTTPHandler(h *debugstatus.Handler) http.Handler {
 
 func (s *handlerSuite) TestServeDebugStatus(c *gc.C) {
 	httpHandler := newHTTPHandler(&debugstatus.Handler{
-		Check: func() map[string]debugstatus.CheckResult {
-			return debugstatus.Check(debugstatus.ServerStartTime)
+		Check: func(ctx context.Context) map[string]debugstatus.CheckResult {
+			return debugstatus.Check(ctx, debugstatus.ServerStartTime)
 		},
 	})
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{


### PR DESCRIPTION
This means that we can pass the context through from
the handler to the checker without needing to create
a new debugstatus handler for every request.