### PR TITLE
Fix NoSuchUserErrRegexp on Unix 

### DIFF
--- a/file_test.go
+++ b/file_test.go
@@ -60,7 +60,7 @@ func (*fileSuite) TestNormalizePath(c *gc.C) {
 		expected: filepath.FromSlash("foo~bar/baz"),
 	}, {
 		path: "~foobar/path",
-		err:  ".*" + utils.NoSuchUserErrRegexp,
+		err:  utils.NoSuchUserErrRegexp + ".*",
 	}} {
 		c.Logf("test %d: %s", i, test.path)
 		actual, err := utils.NormalizePath(test.path)

--- a/systemerrmessages_unix.go
+++ b/systemerrmessages_unix.go
@@ -10,7 +10,7 @@ package utils
 // that may be returned in case of failed calls to the system.
 // Any extra leading/trailing regex-es are left to be added by the developer.
 const (
-	NoSuchUserErrRegexp = `user: unknown user [a-z0-9_-]*`
+	NoSuchUserErrRegexp = `no such user`
 	NoSuchFileErrRegexp = `no such file or directory`
 	MkdirFailErrRegexp  = `.* not a directory`
 )


### PR DESCRIPTION
When running `go test github.com/juju/utils` I get the following error on Fedora 26 with `golang-1.8.5-1`:
```
[...]
FAIL: file_test.go:26: fileSuite.TestNormalizePath

test 0: /var/lib/juju
test 1: ~/foo
test 2: ~/foo//../bar
test 3: ~
test 4: ~mockbuild
test 5: ~mockbuild/foo
test 6: ~mockbuild/foo//../bar
test 7: foo~bar/baz
test 8: ~foobar/path
file_test.go:68:
    c.Check(err, gc.ErrorMatches, test.err)
... error string = "no such user: user: lookup username foobar: no such file or directory"
... regex string = ".*user: unknown user [a-z0-9_-]*"

The attached patches will fix this error.
```