### PR TITLE
ctxutil: new package

### DIFF
--- a/ctxutil/ctxutil_test.go
+++ b/ctxutil/ctxutil_test.go
@@ -1,0 +1,178 @@
+// Copyright 2016 Canonical Ltd.
+
+package ctxutil_test
+
+import (
+	"time"
+
+	"golang.org/x/net/context"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils/ctxutil"
+)
+
+type ctxutilSuite struct {
+}
+
+var _ = gc.Suite(&ctxutilSuite{})
+
+func (s *ctxutilSuite) TestJoinCancel1(c *gc.C) {
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx := ctxutil.Join(ctx1, context.Background())
+	cancel1()
+	waitFor(c, ctx.Done())
+	c.Assert(ctx.Err(), gc.Equals, context.Canceled)
+}
+
+func (s *ctxutilSuite) TestJoinCancel2(c *gc.C) {
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx := ctxutil.Join(context.Background(), ctx1)
+	cancel1()
+	waitFor(c, ctx.Done())
+	c.Assert(ctx.Err(), gc.Equals, context.Canceled)
+}
+
+func (s *ctxutilSuite) TestJoinCancelBoth1(c *gc.C) {
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	ctx := ctxutil.Join(ctx1, ctx2)
+	cancel1()
+	waitFor(c, ctx.Done())
+	c.Assert(ctx.Err(), gc.Equals, context.Canceled)
+}
+
+func (s *ctxutilSuite) TestErrNoErr(c *gc.C) {
+	ctx := ctxutil.Join(context.Background(), context.Background())
+	c.Assert(ctx.Err(), gc.Equals, nil)
+}
+
+func (s *ctxutilSuite) TestJoinCancelBoth2(c *gc.C) {
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	ctx := ctxutil.Join(ctx1, ctx2)
+	cancel2()
+	waitFor(c, ctx.Done())
+	c.Assert(ctx.Err(), gc.Equals, context.Canceled)
+}
+
+func (s *ctxutilSuite) TestDeadline1(c *gc.C) {
+	t := time.Now().Add(5 * time.Second).UTC()
+	ctx1, cancel1 := context.WithDeadline(context.Background(), t)
+	defer cancel1()
+	ctx := ctxutil.Join(ctx1, context.Background())
+	deadline, ok := ctx.Deadline()
+	c.Assert(ok, gc.Equals, true)
+	c.Assert(deadline, gc.Equals, t)
+}
+
+func (s *ctxutilSuite) TestDeadline2(c *gc.C) {
+	t := time.Now().Add(5 * time.Second).UTC()
+	ctx1, cancel1 := context.WithDeadline(context.Background(), t)
+	defer cancel1()
+	ctx := ctxutil.Join(context.Background(), ctx1)
+	deadline, ok := ctx.Deadline()
+	c.Assert(ok, gc.Equals, true)
+	c.Assert(deadline, gc.Equals, t)
+}
+
+func (s *ctxutilSuite) TestDeadlineBoth1(c *gc.C) {
+	t1 := time.Now().Add(5 * time.Second).UTC()
+	ctx1, cancel1 := context.WithDeadline(context.Background(), t1)
+	defer cancel1()
+
+	t2 := time.Now().Add(10 * time.Second).UTC()
+	ctx2, cancel2 := context.WithDeadline(context.Background(), t2)
+	defer cancel2()
+
+	ctx := ctxutil.Join(ctx1, ctx2)
+
+	deadline, ok := ctx.Deadline()
+	c.Assert(ok, gc.Equals, true)
+	c.Assert(deadline, gc.Equals, t1)
+}
+
+func (s *ctxutilSuite) TestDeadlineBoth2(c *gc.C) {
+	t1 := time.Now().Add(5 * time.Second).UTC()
+	ctx1, cancel1 := context.WithDeadline(context.Background(), t1)
+	defer cancel1()
+
+	t2 := time.Now().Add(10 * time.Second).UTC()
+	ctx2, cancel2 := context.WithDeadline(context.Background(), t2)
+	defer cancel2()
+
+	ctx := ctxutil.Join(ctx2, ctx1)
+
+	deadline, ok := ctx.Deadline()
+	c.Assert(ok, gc.Equals, true)
+	c.Assert(deadline, gc.Equals, t1)
+}
+
+func (s *ctxutilSuite) TestValue1(c *gc.C) {
+	ctx1 := context.WithValue(context.Background(), "foo", "bar")
+	ctx := ctxutil.Join(ctx1, context.Background())
+	c.Assert(ctx.Value("foo"), gc.Equals, "bar")
+}
+
+func (s *ctxutilSuite) TestValue2(c *gc.C) {
+	ctx1 := context.WithValue(context.Background(), "foo", "bar")
+	ctx := ctxutil.Join(context.Background(), ctx1)
+	c.Assert(ctx.Value("foo"), gc.Equals, "bar")
+}
+
+func (s *ctxutilSuite) TestValueBoth(c *gc.C) {
+	ctx1 := context.WithValue(context.Background(), "foo", "bar1")
+	ctx2 := context.WithValue(context.Background(), "foo", "bar2")
+	ctx := ctxutil.Join(ctx1, ctx2)
+	c.Assert(ctx.Value("foo"), gc.Equals, "bar1")
+}
+
+func (s *ctxutilSuite) TestDoneRace(c *gc.C) {
+	// This test is designed to be run with the race detector enabled.
+	ctx1, cancel1 := context.WithDeadline(context.Background(), time.Now())
+	defer cancel1()
+	ctx2, cancel2 := context.WithDeadline(context.Background(), time.Now())
+	defer cancel2()
+	ctx := ctxutil.Join(ctx1, ctx2)
+	done := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		done <- struct{}{}
+	}()
+	go func() {
+		<-ctx.Done()
+		done <- struct{}{}
+	}()
+	waitFor(c, done)
+	waitFor(c, done)
+}
+
+func (s *ctxutilSuite) TestErrRace(c *gc.C) {
+	// This test is designed to be run with the race detector enabled.
+	ctx1, cancel1 := context.WithDeadline(context.Background(), time.Now())
+	defer cancel1()
+	ctx2, cancel2 := context.WithDeadline(context.Background(), time.Now())
+	defer cancel2()
+	ctx := ctxutil.Join(ctx1, ctx2)
+	done := make(chan struct{})
+	go func() {
+		ctx.Err()
+		done <- struct{}{}
+	}()
+	go func() {
+		ctx.Err()
+		done <- struct{}{}
+	}()
+	waitFor(c, done)
+	waitFor(c, done)
+}
+
+func waitFor(c *gc.C, ch <-chan struct{}) {
+	select {
+	case <-ch:
+		return
+	case <-time.After(time.Second):
+		c.Fatalf("timed out")
+	}
+}

--- a/ctxutil/join.go
+++ b/ctxutil/join.go
@@ -1,0 +1,116 @@
+// Package ctxutil holds utilities related to the context package.
+package ctxutil
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+type joinedContext struct {
+	done1, done2 <-chan struct{}
+	ctx1, ctx2   context.Context
+
+	// doneOnce guards done.
+	doneOnce sync.Once
+	done     <-chan struct{}
+
+	// errOnce guards err.
+	errOnce sync.Once
+	err     error
+}
+
+// Join joins the two contexts into one context that contains
+// all the values in each and that is canceled when
+// either is canceled. If both contain a value with the
+// same key, ctx1 is preferred. If Err is called when
+// both are done, the error from ctx1 will be returned.
+func Join(ctx1, ctx2 context.Context) context.Context {
+	ctx := &joinedContext{
+		done1: ctx1.Done(),
+		done2: ctx2.Done(),
+		ctx1:  ctx1,
+		ctx2:  ctx2,
+	}
+	switch {
+	case ctx.done1 != nil && ctx.done2 == nil:
+		ctx.done = ctx.done1
+	case ctx.done1 == nil && ctx.done2 != nil:
+		ctx.done = ctx.done2
+	}
+	return ctx
+}
+
+// Deadline implements context.Context.Deadline
+// by returning the earlier of the two deadlines.
+func (ctx *joinedContext) Deadline() (deadline time.Time, ok bool) {
+	d1, ok1 := ctx.ctx1.Deadline()
+	d2, ok2 := ctx.ctx2.Deadline()
+	switch {
+	case ok1 && ok2:
+		if d1.Before(d2) {
+			return d1, true
+		}
+		return d2, true
+	case ok1:
+		return d1, true
+	}
+	return d2, ok2
+}
+
+// Done implements context.Context.Done by returning
+// a channel which is closed when either child context's
+// Done value is closed.
+func (ctx *joinedContext) Done() <-chan struct{} {
+	if ctx.done1 == nil || ctx.done2 == nil {
+		// Easy case when we don't need to combine two done channels.
+		return ctx.done
+	}
+	// Start a goroutine to wait for either child context to be done.
+	// Note that we do assume that a non-nil Done channel will always
+	// eventually be closed. If it isn't we should consider that a bug.
+	ctx.doneOnce.Do(func() {
+		done := make(chan struct{})
+		ctx.done = done
+		go func() {
+			select {
+			case <-ctx.done1:
+			case <-ctx.done2:
+			}
+			close(done)
+		}()
+	})
+	return ctx.done
+}
+
+// Err implements context.Context.Err by returning an error from
+// either child context.
+func (ctx *joinedContext) Err() error {
+	err1 := ctx.ctx1.Err()
+	err2 := ctx.ctx2.Err()
+	if err1 == nil && err2 == nil {
+		return nil
+	}
+	// Make sure that once we have returned an error, we always
+	// return the same one.
+	ctx.errOnce.Do(func() {
+		if err1 != nil {
+			// If both contexts have an error, we prefer the error from
+			// the first context.
+			ctx.err = err1
+		} else {
+			ctx.err = err2
+		}
+	})
+	return ctx.err
+}
+
+// Value implements context.Context.Value by returning a value
+// from either child context, giving precedence to ctx.ctx1.
+func (ctx *joinedContext) Value(key interface{}) interface{} {
+	if v := ctx.ctx1.Value(key); v != nil {
+		return v
+	}
+	return ctx.ctx2.Value(key)
+}

--- a/ctxutil/package_test.go
+++ b/ctxutil/package_test.go
@@ -1,0 +1,13 @@
+// Copyright 2016 Canonical Ltd.
+
+package ctxutil_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
We implement a Join function for contexts, which can be
useful when contexts from two origins arrive in the same
place (for example when a long-lived context passed
to a worker interacts with a context created for a single
HTTP request).