### PR TITLE
keyvalues.Join

### DIFF
--- a/keyvalues/keyvalues.go
+++ b/keyvalues/keyvalues.go
@@ -8,6 +8,7 @@ package keyvalues
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -38,4 +39,15 @@ func Parse(src []string, allowEmptyValues bool) (map[string]string, error) {
 		results[key] = value
 	}
 	return results, nil
+}
+
+// Join returns a sorted slice containing each item in the given map, as
+// "key=value" strings.
+func Join(m map[string]string) []string {
+	var result []string
+	for k, v := range m {
+		result = append(result, fmt.Sprintf("%s=%s", k, v))
+	}
+	sort.Strings(result)
+	return result
 }

--- a/keyvalues/keyvalues_test.go
+++ b/keyvalues/keyvalues_test.go
@@ -129,3 +129,10 @@ func (keyValuesSuite) TestMapParsing(c *gc.C) {
 		}
 	}
 }
+
+func (keyValuesSuite) TestJoin(c *gc.C) {
+	c.Assert(keyvalues.Join(map[string]string{}), gc.HasLen, 0)
+	c.Assert(keyvalues.Join(map[string]string{"foo": "bar"}), gc.DeepEquals, []string{"foo=bar"})
+	c.Assert(keyvalues.Join(map[string]string{"abc": "123", "foo": "bar", "quux": "baz"}),
+		gc.DeepEquals, []string{"abc=123", "foo=bar", "quux=baz"})
+}


### PR DESCRIPTION
Adds a utility function that joins string maps into a slice of "key=value" string representations for the purpose of sorting by and displaying string map fields.

This function is not intended to be a perfect complement to Parse.