### PR TITLE
IsFileOwner is file owned by user

### DIFF
--- a/file_unix.go
+++ b/file_unix.go
@@ -80,7 +80,7 @@ func ChownPath(path, username string) error {
 func IsFileOwner(path, username string) (bool, error) {
 	u, err := user.Lookup(username)
 	if err != nil {
-		return false, fmt.Errorf("cannot lookup %q user id: %v", username, err)
+		return false, errors.Annotatef(err, "cannot lookup %q user id", username)
 	}
 	info, err := os.Stat(path)
 	if err != nil {

--- a/file_unix.go
+++ b/file_unix.go
@@ -11,6 +11,7 @@ import (
 	"os/user"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/juju/errors"
 )
@@ -72,4 +73,23 @@ func ChownPath(path, username string) error {
 		return fmt.Errorf("invalid group id %q: %v", u.Gid, err)
 	}
 	return os.Chown(path, uid, gid)
+}
+
+// IsFileOwner checks to see if the ownership of the file corresponds to
+// the same username
+func IsFileOwner(path, username string) (bool, error) {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return false, fmt.Errorf("cannot lookup %q user id: %v", username, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, fmt.Errorf("cannot lookup %q file", path)
+	}
+	return (strconv.Itoa(int(stat.Uid)) == u.Uid &&
+		strconv.Itoa(int(stat.Gid)) == u.Gid), nil
 }

--- a/file_unix_test.go
+++ b/file_unix_test.go
@@ -6,6 +6,11 @@
 package utils_test
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/utils"
@@ -20,4 +25,27 @@ func (s *unixFileSuite) TestEnsureBaseDir(c *gc.C) {
 	c.Assert(utils.EnsureBaseDir(`/a`, `/b/c`), gc.Equals, `/a/b/c`)
 	c.Assert(utils.EnsureBaseDir(`/`, `/b/c`), gc.Equals, `/b/c`)
 	c.Assert(utils.EnsureBaseDir(``, `/b/c`), gc.Equals, `/b/c`)
+}
+
+func (s *unixFileSuite) TestFileOwner(c *gc.C) {
+	username, err := utils.LocalUsername()
+	c.Assert(err, gc.IsNil)
+
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("file-%d", time.Now().Unix()))
+	_, err = os.Create(path)
+	c.Assert(err, gc.IsNil)
+
+	ok, err := utils.IsFileOwner(path, username)
+	c.Assert(err, gc.IsNil)
+	c.Assert(ok, gc.Equals, true)
+}
+
+func (s *unixFileSuite) TestFileOwnerUsingRoot(c *gc.C) {
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("file-%d", time.Now().Unix()))
+	_, err := os.Create(path)
+	c.Assert(err, gc.IsNil)
+
+	ok, err := utils.IsFileOwner(path, "root")
+	c.Assert(err, gc.IsNil)
+	c.Assert(ok, gc.Equals, false)
 }

--- a/file_unix_test.go
+++ b/file_unix_test.go
@@ -13,6 +13,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/errors"
 	"github.com/juju/utils"
 )
 
@@ -31,7 +32,7 @@ func (s *unixFileSuite) TestFileOwner(c *gc.C) {
 	username, err := utils.LocalUsername()
 	c.Assert(err, gc.IsNil)
 
-	path := filepath.Join(os.TempDir(), fmt.Sprintf("file-%d", time.Now().Unix()))
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("file-%d", time.Now().UnixNano()))
 	_, err = os.Create(path)
 	c.Assert(err, gc.IsNil)
 
@@ -41,11 +42,31 @@ func (s *unixFileSuite) TestFileOwner(c *gc.C) {
 }
 
 func (s *unixFileSuite) TestFileOwnerUsingRoot(c *gc.C) {
-	path := filepath.Join(os.TempDir(), fmt.Sprintf("file-%d", time.Now().Unix()))
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("file-%d", time.Now().UnixNano()))
 	_, err := os.Create(path)
 	c.Assert(err, gc.IsNil)
 
 	ok, err := utils.IsFileOwner(path, "root")
 	c.Assert(err, gc.IsNil)
+	c.Assert(ok, gc.Equals, false)
+}
+
+func (s *unixFileSuite) TestFileOwnerWithInvalidPath(c *gc.C) {
+	username, err := utils.LocalUsername()
+	c.Assert(err, gc.IsNil)
+
+	path := filepath.Join(os.TempDir(), "file-bad")
+	ok, err := utils.IsFileOwner(path, username)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "stat .*: no such file or directory")
+	c.Assert(ok, gc.Equals, false)
+}
+
+func (s *unixFileSuite) TestFileOwnerWithInvalidUsername(c *gc.C) {
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("file-%d", time.Now().UnixNano()))
+	_, err := os.Create(path)
+	c.Assert(err, gc.IsNil)
+
+	ok, err := utils.IsFileOwner(path, "invalid")
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "user: unknown user invalid")
 	c.Assert(ok, gc.Equals, false)
 }

--- a/file_windows.go
+++ b/file_windows.go
@@ -140,3 +140,8 @@ func ChownPath(path, username string) error {
 	// way and hasn't yet been implemented.
 	return nil
 }
+
+// IsFileOwner is not implemented for Windows.
+func IsFileOwner(path, username string) (bool, error) {
+	return true, nil
+}

--- a/file_windows_test.go
+++ b/file_windows_test.go
@@ -48,3 +48,7 @@ func (s *windowsFileSuite) TestEnsureBaseDir(c *gc.C) {
 	c.Assert(utils.EnsureBaseDir(`C:`, `\a\b`), gc.Equals, `C:\a\b`)
 	c.Assert(utils.EnsureBaseDir(``, `C:\a\b`), gc.Equals, `C:\a\b`)
 }
+
+func (s *windowsFileSuite) TestFileOwner(c *gc.C) {
+	c.Assert(utils.IsFileOwner("file://C:\\foo\\baz", "timmy"), gc.Equals, true)
+}


### PR DESCRIPTION
The following adds the ability to check if the current file is owned
by the user supplied. If the user can not be found, or no information
about the file can be found, then it will error out.

The windows version is not supplied, as there isn't a need for it,
but could be researched to see if it could be.