### PR TITLE
support multiple feature flags

### DIFF
--- a/featureflag/flags.go
+++ b/featureflag/flags.go
@@ -60,17 +60,22 @@ func setFlags(val string) {
 	}
 }
 
-// Enabled is used to determine if a particular feature flag is enabled for
+// Enabled is used to determine if a particular feature flag/s is/are enabled for
 // the process.
-func Enabled(flag string) bool {
+func Enabled(givenFlags ...string) bool {
 	flaglock.Lock()
 	defer flaglock.Unlock()
-	flag = strings.TrimSpace(strings.ToLower(flag))
-	if flag == "" {
-		// The empty feature is always enabled.
-		return true
+	for _, value := range givenFlags {
+		value = strings.TrimSpace(strings.ToLower(value))
+		if value == "" {
+			// The empty feature is always enabled.
+			return true
+		}
+		if flags.Contains(value) {
+			return true
+		}
 	}
-	return flags.Contains(flag)
+	return false
 }
 
 // All returns all the current feature flags.

--- a/featureflag/flags_test.go
+++ b/featureflag/flags_test.go
@@ -45,3 +45,14 @@ func (s *flagSuite) TestEnabled(c *gc.C) {
 	c.Assert(featureflag.Enabled("Magic"), jc.IsTrue)
 	c.Assert(featureflag.Enabled(" MAGIC "), jc.IsTrue)
 }
+
+// Assume we migrated from an old version to a new one.
+// Out of UX reasons we try to support multiple featureflags for the same feature as below.
+func (s *flagSuite) TestEnabledMultiple(c *gc.C) {
+	s.PatchEnvironment("JUJU_TESTING_FEATURE", "MAGIC")
+	featureflag.SetFlagsFromEnvironment("JUJU_TESTING_FEATURE")
+
+	c.Assert(featureflag.Enabled("magic", "oldMagic"), jc.IsTrue)
+	c.Assert(featureflag.Enabled("Magic", "oldMagic"), jc.IsTrue)
+	c.Assert(featureflag.Enabled(" MAGIC ", "oldMagic"), jc.IsTrue)
+}


### PR DESCRIPTION
support multiple feature flags by using variadic functions to ensure backward compatibility.

Tests should show patch change.