### PR TITLE
Fix WinRM Run() function

### DIFF
--- a/winrm/winrm.go
+++ b/winrm/winrm.go
@@ -211,8 +211,11 @@ func NewClient(config ClientConfig) (*Client, error) {
 // If the Run successfully executes it returns nil
 func (c *Client) Run(command string, stdout io.Writer, stderr io.Writer) error {
 	logger.Debugf("Runing cmd on WinRM connection %q", command)
-	_, err := c.conn.Run(command, stdout, stderr)
-	if err != nil {
+	exitCode, err := c.conn.Run(command, stdout, stderr)
+	if exitCode != 0 {
+		if err == nil {
+			err = errors.Errorf("exit status %d", exitCode)
+		}
 		return errors.Annotatef(err, "cannot run WinRM command %q", command)
 	}
 	return nil


### PR DESCRIPTION
This change makes the ```Run()``` function rely on the exit code of the command being run, instead of the ```err``` variable returned by the winrm module.

In the past, some ```powershell``` versions did not properly set the exit code on all versions of windows. As a result, we would get an error, but the exit code was being set to ```0```. Back then, the only way to tell if an error occurred, was to look at ```stderr```, which is bad.

Since then, updates have fixed those kinds of scenarios, and we need to look at the actual exit code.

In the case of running powershell over WinRM, some powershell commandlets will generate a progress bar, which unfortunately will output the progress to ```stderr```. This means that successful commands will report errors, which makes the manual provider unusable with Windows.

This is the first patch in fixing the already existing manual provider support for Windows machines.