### PR TITLE
Add option to set feature flags from more than one env var

### DIFF
--- a/featureflag/flags.go
+++ b/featureflag/flags.go
@@ -41,21 +41,26 @@ var (
 // program startup (or tests), and it is serialized by the runtime, we don't
 // use any mutux when setting the flag set.  Should this change in the future,
 // a mutex should be used.
-func SetFlagsFromEnvironment(envVarName string) {
-	setFlags(os.Getenv(envVarName))
+func SetFlagsFromEnvironment(envVarNames ...string) {
+	rawValues := make([]string, len(envVarNames))
+	for i, envVarName := range envVarNames {
+		rawValues[i] = os.Getenv(envVarName)
+	}
+	setFlags(rawValues...)
 }
 
-// setFlags populates the global set using a string passed to it containing the
+// setFlags populates the global set using string(s) passed to it containing the
 // flags.
-func setFlags(val string) {
-	values := strings.ToLower(val)
-
+func setFlags(rawValues ...string) {
 	flaglock.Lock()
 	defer flaglock.Unlock()
 	flags = set.NewStrings()
-	for _, flag := range strings.Split(values, ",") {
-		if flag = strings.TrimSpace(flag); flag != "" {
-			flags.Add(flag)
+	for _, values := range rawValues {
+		values = strings.ToLower(values)
+		for _, flag := range strings.Split(values, ",") {
+			if flag = strings.TrimSpace(flag); flag != "" {
+				flags.Add(flag)
+			}
 		}
 	}
 }

--- a/featureflag/flags_test.go
+++ b/featureflag/flags_test.go
@@ -27,21 +27,27 @@ func (s *flagSuite) TestEmpty(c *gc.C) {
 
 func (s *flagSuite) TestParsing(c *gc.C) {
 	s.PatchEnvironment("JUJU_TESTING_FEATURE", "MAGIC, test, space ")
-	featureflag.SetFlagsFromEnvironment("JUJU_TESTING_FEATURE")
-	c.Assert(featureflag.All(), jc.SameContents, []string{"magic", "space", "test"})
-	c.Assert(featureflag.AsEnvironmentValue(), gc.Equals, "magic,space,test")
-	c.Assert(featureflag.String(), gc.Equals, `"magic", "space", "test"`)
+	s.PatchEnvironment("JUJU_TESTING_FEATURE2", "magic2")
+	featureflag.SetFlagsFromEnvironment("JUJU_TESTING_FEATURE", "JUJU_TESTING_FEATURE2")
+	c.Assert(featureflag.All(), jc.SameContents, []string{"magic", "space", "test", "magic2"})
+	c.Assert(featureflag.AsEnvironmentValue(), gc.Equals, "magic,magic2,space,test")
+	c.Assert(featureflag.String(), gc.Equals, `"magic", "magic2", "space", "test"`)
 }
 
 func (s *flagSuite) TestEnabled(c *gc.C) {
 	c.Assert(featureflag.Enabled(""), jc.IsTrue)
 	c.Assert(featureflag.Enabled(" "), jc.IsTrue)
 	c.Assert(featureflag.Enabled("magic"), jc.IsFalse)
+	c.Assert(featureflag.Enabled("magic2"), jc.IsFalse)
 
 	s.PatchEnvironment("JUJU_TESTING_FEATURE", "MAGIC")
-	featureflag.SetFlagsFromEnvironment("JUJU_TESTING_FEATURE")
+	s.PatchEnvironment("JUJU_TESTING_FEATURE2", "MAGIC2")
+	featureflag.SetFlagsFromEnvironment("JUJU_TESTING_FEATURE", "JUJU_TESTING_FEATURE2")
 
 	c.Assert(featureflag.Enabled("magic"), jc.IsTrue)
 	c.Assert(featureflag.Enabled("Magic"), jc.IsTrue)
 	c.Assert(featureflag.Enabled(" MAGIC "), jc.IsTrue)
+	c.Assert(featureflag.Enabled("magic2"), jc.IsTrue)
+	c.Assert(featureflag.Enabled("Magic2"), jc.IsTrue)
+	c.Assert(featureflag.Enabled(" MAGIC2 "), jc.IsTrue)
 }

--- a/featureflag/flags_windows.go
+++ b/featureflag/flags_windows.go
@@ -20,8 +20,12 @@ import (
 // program startup (or tests), and it is serialized by the runtime, we don't
 // use any mutux when setting the flag set.  Should this change in the future,
 // a mutex should be used.
-func SetFlagsFromRegistry(regVarKey string, regVarName string) {
-	setFlags(getFlagsFromRegistry(regVarKey, regVarName))
+func SetFlagsFromRegistry(regVarKey string, regVarNames ...string) {
+	rawValues := make([]string, len(regVarNames))
+	for i, regVarName := range regVarNames {
+		rawValues[i] = getFlagsFromRegistry(regVarKey, regVarName)
+	}
+	setFlags(rawValues...)
 }
 
 // getFlagsFromRegistry returns the string value from a registry key

--- a/series/supportedseries_test.go
+++ b/series/supportedseries_test.go
@@ -146,7 +146,7 @@ func (s *supportedSeriesSuite) TestLatestLts(c *gc.C) {
 		latest, want string
 	}{
 		{"testseries", "testseries"},
-		{"", "bionic"},
+		{"", "focal"},
 	}
 	for _, test := range table {
 		series.SetLatestLtsForTesting(test.latest)
@@ -159,7 +159,7 @@ func (s *supportedSeriesSuite) TestSetLatestLtsForTesting(c *gc.C) {
 	table := []struct {
 		value, want string
 	}{
-		{"1", "bionic"}, {"2", "1"}, {"3", "2"}, {"4", "3"},
+		{"1", "focal"}, {"2", "1"}, {"3", "2"}, {"4", "3"},
 	}
 	for _, test := range table {
 		got := series.SetLatestLtsForTesting(test.value)
@@ -169,6 +169,6 @@ func (s *supportedSeriesSuite) TestSetLatestLtsForTesting(c *gc.C) {
 
 func (s *supportedSeriesSuite) TestSupportedLts(c *gc.C) {
 	got := series.SupportedLts()
-	want := []string{"precise", "trusty", "xenial", "bionic"}
+	want := []string{"precise", "trusty", "xenial", "bionic", "focal"}
 	c.Assert(got, gc.DeepEquals, want)
 }


### PR DESCRIPTION
Enhance SetFlagsFromEnvironment() so that you can pass in more than one env var from which to extract feature flags.
Same with SetFlagsFromRegistry().