### PR TITLE
Ignore empty source strings when parsing key/value options

### DIFF
--- a/keyvalues/keyvalues.go
+++ b/keyvalues/keyvalues.go
@@ -24,6 +24,9 @@ func (e DuplicateError) Error() string {
 func Parse(src []string, allowEmptyValues bool) (map[string]string, error) {
 	results := map[string]string{}
 	for _, kv := range src {
+		if kv == "" {
+			continue
+		}
 		parts := strings.SplitN(kv, "=", 2)
 		if len(parts) != 2 {
 			return nil, fmt.Errorf(`expected "key=value", got %q`, kv)

--- a/keyvalues/keyvalues_test.go
+++ b/keyvalues/keyvalues_test.go
@@ -115,6 +115,12 @@ var testCases = []struct {
 	allowEmptyVal: true,
 	output:        nil,
 	error:         `expected "key=value", got "=value"`,
+}, {
+	about:         "empty inputs are skipped",
+	input:         []string{"key=value", "", "foo=bar"},
+	allowEmptyVal: true,
+	output:        map[string]string{"key": "value", "foo": "bar"},
+	error:         "",
 }}
 
 func (keyValuesSuite) TestMapParsing(c *gc.C) {


### PR DESCRIPTION
This PR makes the kv-parsing code a bit more robust by having it skip over any empty strings that are passed to it as input.