### PR TITLE
Home() returns real home, not snap home

### DIFF
--- a/home_unix.go
+++ b/home_unix.go
@@ -1,5 +1,6 @@
 // Copyright 2013 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
+//go:build !windows
 // +build !windows
 
 package utils
@@ -8,8 +9,16 @@ import (
 	"os"
 )
 
-// Home returns the os-specific home path as specified in the environment.
+// Home returns the os-specific home path.
+// Always returns the "real" home, not the
+// confined home that is used when running
+// inside a strictly confined snap.
 func Home() string {
+	// Used when running inside a confined snap.
+	realHome := os.Getenv("SNAP_REAL_HOME")
+	if realHome != "" {
+		return realHome
+	}
 	return os.Getenv("HOME")
 }
 

--- a/home_unix_test.go
+++ b/home_unix_test.go
@@ -1,5 +1,6 @@
 // Copyright 2011, 2012, 2013 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
+//go:build !windows
 // +build !windows
 
 package utils_test
@@ -20,5 +21,12 @@ var _ = gc.Suite(&homeSuite{})
 func (s *homeSuite) TestHomeLinux(c *gc.C) {
 	h := "/home/foo/bar"
 	s.PatchEnvironment("HOME", h)
+	c.Check(utils.Home(), gc.Equals, h)
+}
+
+func (s *homeSuite) TestHomeConfined(c *gc.C) {
+	h := "/home/foo/bar"
+	s.PatchEnvironment("HOME", "/home/user/snap/foo/1")
+	s.PatchEnvironment("SNAP_REAL_HOME", h)
 	c.Check(utils.Home(), gc.Equals, h)
 }


### PR DESCRIPTION
When running inside a strictly confined snap, `$HOME` is set to a path under `~/snap/foo` which is accessible to the snap without needing to use the `home` interface. However, looking up the home directory of a named user using the Go library APIs still returns the real home. And things like `NormalisePath()` will also use the real home if `~user/path` is used, but not `~/path`.

So for consistency, `Home()` is tweaked to always return the real home. If we want to use the confined home, we can add extra logic for that if/when needed. NB A strictly confined juju will use the real home.