### PR TITLE
[JUJU-1750] Add riscv among supported architectures

### DIFF
--- a/arch/arch.go
+++ b/arch/arch.go
@@ -17,6 +17,7 @@ const (
 	ARM64   = "arm64"
 	PPC64EL = "ppc64el"
 	S390X   = "s390x"
+	RISCV64 = "riscv64"
 
 	// Older versions of Juju used "ppc64" instead of ppc64el
 	LEGACY_PPC64 = "ppc64"
@@ -30,6 +31,7 @@ var AllSupportedArches = []string{
 	ARM64,
 	PPC64EL,
 	S390X,
+	RISCV64,
 }
 
 // Info records the information regarding each architecture recognised by Juju.
@@ -40,6 +42,7 @@ var Info = map[string]ArchInfo{
 	ARM64:   {64},
 	PPC64EL: {64},
 	S390X:   {64},
+	RISCV64: {64},
 }
 
 // ArchInfo is a struct containing information about a supported architecture.
@@ -60,6 +63,7 @@ var archREs = []struct {
 	{regexp.MustCompile("aarch64"), ARM64},
 	{regexp.MustCompile("ppc64|ppc64el|ppc64le"), PPC64EL},
 	{regexp.MustCompile("s390x"), S390X},
+	{regexp.MustCompile("risc$|risc-[vV]64"), RISCV64},
 }
 
 // Override for testing.

--- a/arch/arch.go
+++ b/arch/arch.go
@@ -63,7 +63,7 @@ var archREs = []struct {
 	{regexp.MustCompile("aarch64"), ARM64},
 	{regexp.MustCompile("ppc64|ppc64el|ppc64le"), PPC64EL},
 	{regexp.MustCompile("s390x"), S390X},
-	{regexp.MustCompile("risc$|risc-[vV]64"), RISCV64},
+	{regexp.MustCompile("riscv64|risc$|risc-[vV]64"), RISCV64},
 }
 
 // Override for testing.

--- a/arch/arch_test.go
+++ b/arch/arch_test.go
@@ -40,6 +40,9 @@ func (s *archSuite) TestNormaliseArch(c *gc.C) {
 		{"ppc64le", "ppc64el"},
 		{"ppc64", "ppc64el"},
 		{"s390x", "s390x"},
+		{"risc", "riscv64"},
+		{"risc-v64", "riscv64"},
+		{"risc-V64", "riscv64"},
 	} {
 		arch := arch.NormaliseArch(test.raw)
 		c.Check(arch, gc.Equals, test.arch)

--- a/arch/arch_test.go
+++ b/arch/arch_test.go
@@ -40,6 +40,7 @@ func (s *archSuite) TestNormaliseArch(c *gc.C) {
 		{"ppc64le", "ppc64el"},
 		{"ppc64", "ppc64el"},
 		{"s390x", "s390x"},
+		{"riscv64", "riscv64"},
 		{"risc", "riscv64"},
 		{"risc-v64", "riscv64"},
 		{"risc-V64", "riscv64"},


### PR DESCRIPTION
Adds the `RISC-V` to the list of architectures that Juju recognize. Also added the `risc`, `risc-v64`, `risc-V64` variants.

Note that this does **not** add the `RISC-V32`. I'm not sure if we need it.