### PR TITLE
[WIP] Generate Ed25519 ssh keys instead of RSA-2048

### DIFF
--- a/ssh/clientkeys.go
+++ b/ssh/clientkeys.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-const clientKeyName = "juju_id_rsa"
+const clientKeyName = "juju_id_ed25519"
 
 // PublicKeySuffix is the file extension for public key files.
 const PublicKeySuffix = ".pub"

--- a/ssh/clientkeys_test.go
+++ b/ssh/clientkeys_test.go
@@ -23,8 +23,6 @@ var _ = gc.Suite(&ClientKeysSuite{})
 func (s *ClientKeysSuite) SetUpTest(c *gc.C) {
 	s.FakeHomeSuite.SetUpTest(c)
 	s.AddCleanup(func(*gc.C) { ssh.ClearClientKeys() })
-	generateKeyRestorer := overrideGenerateKey(c)
-	s.AddCleanup(func(*gc.C) { generateKeyRestorer.Restore() })
 }
 
 func checkFiles(c *gc.C, obtained, expected []string) {
@@ -51,7 +49,7 @@ func (s *ClientKeysSuite) TestPublicKeyFiles(c *gc.C) {
 	// and populate it with a key pair.
 	err := ssh.LoadClientKeys("~/.juju/ssh")
 	c.Assert(err, jc.ErrorIsNil)
-	checkPublicKeyFiles(c, "~/.juju/ssh/juju_id_rsa.pub")
+	checkPublicKeyFiles(c, "~/.juju/ssh/juju_id_ed25519.pub")
 	// All files ending with .pub in the client key dir get picked up.
 	priv, pub, err := ssh.GenerateKey("whatever")
 	c.Assert(err, jc.ErrorIsNil)
@@ -61,12 +59,12 @@ func (s *ClientKeysSuite) TestPublicKeyFiles(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	// The new public key won't be observed until the
 	// corresponding private key exists.
-	checkPublicKeyFiles(c, "~/.juju/ssh/juju_id_rsa.pub")
+	checkPublicKeyFiles(c, "~/.juju/ssh/juju_id_ed25519.pub")
 	err = ioutil.WriteFile(gitjujutesting.HomePath(".juju", "ssh", "whatever"), []byte(priv), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	err = ssh.LoadClientKeys("~/.juju/ssh")
 	c.Assert(err, jc.ErrorIsNil)
-	checkPublicKeyFiles(c, "~/.juju/ssh/juju_id_rsa.pub", "~/.juju/ssh/whatever.pub")
+	checkPublicKeyFiles(c, "~/.juju/ssh/juju_id_ed25519.pub", "~/.juju/ssh/whatever.pub")
 }
 
 func (s *ClientKeysSuite) TestPrivateKeyFiles(c *gc.C) {
@@ -75,7 +73,7 @@ func (s *ClientKeysSuite) TestPrivateKeyFiles(c *gc.C) {
 	// unless LoadClientKeys is called again.
 	err := ssh.LoadClientKeys("~/.juju/ssh")
 	c.Assert(err, jc.ErrorIsNil)
-	checkPrivateKeyFiles(c, "~/.juju/ssh/juju_id_rsa")
+	checkPrivateKeyFiles(c, "~/.juju/ssh/juju_id_ed25519")
 	priv, pub, err := ssh.GenerateKey("whatever")
 	c.Assert(err, jc.ErrorIsNil)
 	err = ioutil.WriteFile(gitjujutesting.HomePath(".juju", "ssh", "whatever"), []byte(priv), 0600)
@@ -84,16 +82,16 @@ func (s *ClientKeysSuite) TestPrivateKeyFiles(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	// The new private key won't be observed until the
 	// corresponding public key exists.
-	checkPrivateKeyFiles(c, "~/.juju/ssh/juju_id_rsa")
+	checkPrivateKeyFiles(c, "~/.juju/ssh/juju_id_ed25519")
 	err = ioutil.WriteFile(gitjujutesting.HomePath(".juju", "ssh", "whatever.pub"), []byte(pub), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	// new keys won't be reported until we call LoadClientKeys again
-	checkPublicKeyFiles(c, "~/.juju/ssh/juju_id_rsa.pub")
-	checkPrivateKeyFiles(c, "~/.juju/ssh/juju_id_rsa")
+	checkPublicKeyFiles(c, "~/.juju/ssh/juju_id_ed25519.pub")
+	checkPrivateKeyFiles(c, "~/.juju/ssh/juju_id_ed25519")
 	err = ssh.LoadClientKeys("~/.juju/ssh")
 	c.Assert(err, jc.ErrorIsNil)
-	checkPublicKeyFiles(c, "~/.juju/ssh/juju_id_rsa.pub", "~/.juju/ssh/whatever.pub")
-	checkPrivateKeyFiles(c, "~/.juju/ssh/juju_id_rsa", "~/.juju/ssh/whatever")
+	checkPublicKeyFiles(c, "~/.juju/ssh/juju_id_ed25519.pub", "~/.juju/ssh/whatever.pub")
+	checkPrivateKeyFiles(c, "~/.juju/ssh/juju_id_ed25519", "~/.juju/ssh/whatever")
 }
 
 func (s *ClientKeysSuite) TestLoadClientKeysDirExists(c *gc.C) {
@@ -101,5 +99,5 @@ func (s *ClientKeysSuite) TestLoadClientKeysDirExists(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = ssh.LoadClientKeys("~/.juju/ssh")
 	c.Assert(err, jc.ErrorIsNil)
-	checkPrivateKeyFiles(c, "~/.juju/ssh/juju_id_rsa")
+	checkPrivateKeyFiles(c, "~/.juju/ssh/juju_id_ed25519")
 }

--- a/ssh/export_test.go
+++ b/ssh/export_test.go
@@ -17,7 +17,6 @@ var (
 	InitDefaultClient   = initDefaultClient
 	DefaultIdentities   = &defaultIdentities
 	SSHDial             = &sshDial
-	RSAGenerateKey      = &rsaGenerateKey
 	TestCopyReader      = copyReader
 	TestNewCmd          = newCmd
 )

--- a/ssh/generate.go
+++ b/ssh/generate.go
@@ -4,48 +4,16 @@
 package ssh
 
 import (
+	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	mathrand "math/rand"
 	"strings"
 
 	"github.com/juju/errors"
 	"golang.org/x/crypto/ssh"
 )
-
-// rsaGenerateKey allows for tests to patch out rsa key generation
-var rsaGenerateKey = rsa.GenerateKey
-
-// KeyBits is used to determine the number of bits to use for the RSA keys
-// created using the GenerateKey function.
-var KeyBits = 2048
-
-// GenerateKey makes a 2048 bit RSA no-passphrase SSH capable key.  The bit
-// size is actually controlled by the KeyBits var. The private key returned is
-// encoded to ASCII using the PKCS1 encoding.  The public key is suitable to
-// be added into an authorized_keys file, and has the comment passed in as the
-// comment part of the key.
-func GenerateKey(comment string) (private, public string, err error) {
-	key, err := rsaGenerateKey(rand.Reader, KeyBits)
-	if err != nil {
-		return "", "", errors.Trace(err)
-	}
-
-	identity := pem.EncodeToMemory(
-		&pem.Block{
-			Type:  "RSA PRIVATE KEY",
-			Bytes: x509.MarshalPKCS1PrivateKey(key),
-		})
-
-	public, err = PublicKey(identity, comment)
-	if err != nil {
-		return "", "", errors.Trace(err)
-	}
-
-	return string(identity), public, nil
-}
 
 // PublicKey returns the public key for any private key. The public key is
 // suitable to be added into an authorized_keys file, and has the comment
@@ -56,10 +24,103 @@ func PublicKey(privateKey []byte, comment string) (string, error) {
 		return "", errors.Annotate(err, "failed to load key")
 	}
 
-	auth_key := string(ssh.MarshalAuthorizedKey(signer.PublicKey()))
+	authKey := string(ssh.MarshalAuthorizedKey(signer.PublicKey()))
 	// Strip off the trailing new line so we can add a comment.
-	auth_key = strings.TrimSpace(auth_key)
-	public := fmt.Sprintf("%s %s\n", auth_key, comment)
+	authKey = strings.TrimSpace(authKey)
+	public := fmt.Sprintf("%s %s\n", authKey, comment)
 
 	return public, nil
+}
+
+// GenerateKey generated an Ed25519 no-passphrase SSH capable key. The private
+// key is returned in an OpenSSH compatible format. The public key is suitable
+// to be added into an authorized_keys file. The comment is encoded into the
+// private key, and passed into the comment part of the public key
+func GenerateKey(comment string) (private, public string, err error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", "", errors.Trace(err)
+	}
+
+	publicKey, _ := ssh.NewPublicKey(pub)
+	public = string(ssh.MarshalAuthorizedKey(publicKey))
+	// insert comment to end of the public key in the comment space
+	public = fmt.Sprintf("%s %s\n", strings.TrimSpace(public), comment)
+
+	identity := pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "OPENSSH PRIVATE KEY",
+			Bytes: MarshalEd25519PrivateKey(priv, pub, comment),
+		},
+	)
+	return string(identity), public, nil
+}
+
+// MarshalEd25519PrivateKey formats an Ed25519 private key into a OpenSSH
+// compatible format
+//
+// NOTE(jack-w-shaw, 2023-01-20) Ideally we would a standard library function
+// to do this, as we can with RSA and ECDSA algorithms. But this doesn't seem
+// possible for Ed25519 as an exception. My implementation is based on
+// https://github.com/mikesmitty/edkey
+func MarshalEd25519PrivateKey(privateKey ed25519.PrivateKey, publicKey ed25519.PublicKey, comment string) []byte {
+	// Add our key header (followed by a null byte)
+	out := append([]byte("openssh-key-v1"), 0)
+
+	// Set our check ints
+	ci := mathrand.Uint32()
+
+	keyData := struct {
+		Check1  uint32
+		Check2  uint32
+		Keytype string
+		Pub     []byte
+		Priv    []byte
+		Comment string
+		Pad     []byte `ssh:"rest"`
+	}{
+		Check1:  ci,
+		Check2:  ci,
+		Keytype: ssh.KeyAlgoED25519,
+		Pub:     []byte(publicKey),
+		Priv:    []byte(privateKey),
+		Comment: comment,
+	}
+
+	// Add some padding to match the encryption block size within PrivKeyBlock (without Pad field)
+	// 8 doesn't match the documentation, but that's what ssh-keygen uses for unencrypted keys.
+	bs := 8
+	blockLen := len(ssh.Marshal(keyData))
+	padLen := (bs - (blockLen % bs)) % bs
+	keyData.Pad = make([]byte, padLen)
+
+	// Padding is a sequence of bytes like: 1, 2, 3...
+	for i := 0; i < padLen; i++ {
+		keyData.Pad[i] = byte(i + 1)
+	}
+
+	// Generate the pubkey prefix "\0\0\0\nssh-ed25519\0\0\0 "
+	prefix := []byte{0x0, 0x0, 0x0, 0x0b}
+	prefix = append(prefix, []byte(ssh.KeyAlgoED25519)...)
+	prefix = append(prefix, 0x0, 0x0, 0x0, 0x20)
+
+	keyMeta := struct {
+		CipherName   string
+		KdfName      string
+		KdfOpts      string
+		NumKeys      uint32
+		PubKey       []byte
+		PrivKeyBlock []byte
+	}{
+		// Don't encrypt key
+		CipherName:   "none",
+		KdfName:      "none",
+		KdfOpts:      "",
+		NumKeys:      1,
+		PubKey:       append(prefix, []byte(publicKey)...),
+		PrivKeyBlock: ssh.Marshal(keyData),
+	}
+
+	out = append(out, ssh.Marshal(keyMeta)...)
+	return out
 }

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -205,12 +205,11 @@ func (s *SSHCommandSuite) TestCopy(c *gc.C) {
 }
 
 func (s *SSHCommandSuite) TestCommandClientKeys(c *gc.C) {
-	defer overrideGenerateKey(c).Restore()
 	clientKeysDir := c.MkDir()
 	defer ssh.ClearClientKeys()
 	err := ssh.LoadClientKeys(clientKeysDir)
 	c.Assert(err, jc.ErrorIsNil)
-	ck := filepath.Join(clientKeysDir, "juju_id_rsa")
+	ck := filepath.Join(clientKeysDir, "juju_id_ed25519")
 	var opts ssh.Options
 	opts.SetIdentities("x", "y")
 	s.assertCommandArgs(c, s.commandOptions([]string{echoCommand, "123"}, &opts),


### PR DESCRIPTION
These keys are more secure, smaller and result in quicker speed

Unfortunately, (unlike other keys) the Go standard library doesn't properly marshal Ed25519 keys for SSH. Do this ourselves

### QA Steps

- Delete your `~/.local/share/juju/ssh/juju_id_rsa*` keys
- Compile juju with this branch in place of juju/utils
- Bootstrap a controller and verify Ed25519 keys are generated, and `~/.local/share/juju/ssh/juju_id_rsa.pub` grants access via SSH