### PR TITLE
[JUJU-2465] Increase SSH rsa keys size to 3072 bits

### DIFF
--- a/ssh/generate.go
+++ b/ssh/generate.go
@@ -20,9 +20,9 @@ var rsaGenerateKey = rsa.GenerateKey
 
 // KeyBits is used to determine the number of bits to use for the RSA keys
 // created using the GenerateKey function.
-var KeyBits = 2048
+var KeyBits = 3072
 
-// GenerateKey makes a 2048 bit RSA no-passphrase SSH capable key.  The bit
+// GenerateKey makes a 3072 bit RSA no-passphrase SSH capable key.  The bit
 // size is actually controlled by the KeyBits var. The private key returned is
 // encoded to ASCII using the PKCS1 encoding.  The public key is suitable to
 // be added into an authorized_keys file, and has the comment passed in as the


### PR DESCRIPTION
2048 is no longer considered completely safe, so increase the size to the new industry standard

3072 is a good balance between high security and performance (without changing the algorithm)

### QA Steps

Compile into juju and verify juju generates 3072-bit RSA keys. You can do this by deleting (backing up if necessary) `$HOME/.local/share/juju/ssh/juju_id_rsa*` and bootstrapping a new controller