### PR TITLE
Increase key bit size to 4096

### DIFF
--- a/ssh/generate.go
+++ b/ssh/generate.go
@@ -20,9 +20,9 @@ var rsaGenerateKey = rsa.GenerateKey
 
 // KeyBits is used to determine the number of bits to use for the RSA keys
 // created using the GenerateKey function.
-var KeyBits = 3072
+var KeyBits = 4096
 
-// GenerateKey makes a 3072 bit RSA no-passphrase SSH capable key.  The bit
+// GenerateKey makes a 4096 bit RSA no-passphrase SSH capable key.  The bit
 // size is actually controlled by the KeyBits var. The private key returned is
 // encoded to ASCII using the PKCS1 encoding.  The public key is suitable to
 // be added into an authorized_keys file, and has the comment passed in as the


### PR DESCRIPTION
Increase key bit size to 4096. This is to match the standard recommended by Debian
https://lists.debian.org/debian-devel-announce/2010/09/msg00003.html