### PR TITLE
Adds a new concat func for keys.

### DIFF
--- a/ssh/authorisedkeys.go
+++ b/ssh/authorisedkeys.go
@@ -66,6 +66,22 @@ func ParseAuthorisedKey(line string) (*AuthorisedKey, error) {
 	}, nil
 }
 
+// ConcatAuthorisedKeys will joing two or more authorised keys together to form
+// a string based list of authorised keys that can be read by ssh programs. Keys
+// joined with a newline as the separator.
+func ConcatAuthorisedKeys(a, b string) string {
+	if a == "" {
+		return b
+	}
+	if b == "" {
+		return a
+	}
+	if a[len(a)-1] != '\n' {
+		return a + "\n" + b
+	}
+	return a + b
+}
+
 // SplitAuthorisedKeys extracts a key slice from the specified key data,
 // by splitting the key data into lines and ignoring comments and blank lines.
 func SplitAuthorisedKeys(keyData string) []string {

--- a/ssh/authorisedkeys_test.go
+++ b/ssh/authorisedkeys_test.go
@@ -273,3 +273,14 @@ func (s *AuthorisedKeysKeysSuite) TestParseAuthorisedKey(c *gc.C) {
 		}
 	}
 }
+
+func (s *AuthorisedKeysKeysSuite) TestConcatAuthorisedKeys(c *gc.C) {
+	for _, test := range []struct{ a, b, result string }{
+		{"a", "", "a"},
+		{"", "b", "b"},
+		{"a", "b", "a\nb"},
+		{"a\n", "b", "a\nb"},
+	} {
+		c.Check(ssh.ConcatAuthorisedKeys(test.a, test.b), gc.Equals, test.result)
+	}
+}


### PR DESCRIPTION
In Juju we developed the ability to concat authroised keys for model config. This change moves the code into utils to live along side the rest of our ssh code.

We need this so that we can join multiple sources of authorised keys together safely.

JUJU-5094