### PR TITLE
Add check for new line is ssh key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# GoLand
+.idea/
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+

--- a/ssh/authorisedkeys.go
+++ b/ssh/authorisedkeys.go
@@ -55,6 +55,9 @@ func authKeysDir(username string) (string, error) {
 // authorized_keys file and returns the constituent parts.
 // Based on description in "man sshd".
 func ParseAuthorisedKey(line string) (*AuthorisedKey, error) {
+	if strings.Contains(line, "\n") {
+		return nil, errors.NotValidf("newline in authorized_key %q", line)
+	}
 	key, comment, _, _, err := ssh.ParseAuthorizedKey([]byte(line))
 	if err != nil {
 		return nil, errors.Errorf("invalid authorized_key %q", line)

--- a/ssh/authorisedkeys_test.go
+++ b/ssh/authorisedkeys_test.go
@@ -260,6 +260,9 @@ func (s *AuthorisedKeysKeysSuite) TestParseAuthorisedKey(c *gc.C) {
 	}, {
 		line: "ssh-rsa",
 		err:  "invalid authorized_key \"ssh-rsa\"",
+	}, {
+		line: sshtesting.ValidKeyOne.Key + " line1\nline2",
+		err:  "newline in authorized_key \".*",
 	}} {
 		c.Logf("test %d: %s", i, test.line)
 		ak, err := ssh.ParseAuthorisedKey(test.line)

--- a/ssh/export_test.go
+++ b/ssh/export_test.go
@@ -37,3 +37,9 @@ func PatchTerminal(s *testing.CleanupSuite, rlw ReadLineWriter) {
 		c.Assert(atomic.LoadInt64(&balance), gc.Equals, int64(0))
 	})
 }
+
+func PatchNilTerminal(s *testing.CleanupSuite) {
+	s.PatchValue(&getTerminal, func() (readLineWriter, func(), error) {
+		return nil, func() {}, nil
+	})
+}

--- a/ssh/ssh_gocrypto_test.go
+++ b/ssh/ssh_gocrypto_test.go
@@ -154,12 +154,9 @@ func (s *SSHGoCryptoCommandSuite) SetUpTest(c *gc.C) {
 	generateKeyRestorer := overrideGenerateKey(c)
 	s.AddCleanup(func(*gc.C) { generateKeyRestorer.Restore() })
 
-	client, err := ssh.NewGoCryptoClient()
-	c.Assert(err, jc.ErrorIsNil)
-	s.client = client
-
 	s.knownHostsFile = filepath.Join(c.MkDir(), "known_hosts")
 	ssh.SetGoCryptoKnownHostsFile(s.knownHostsFile)
+	ssh.PatchNilTerminal(&s.CleanupSuite)
 }
 
 func (s *SSHGoCryptoCommandSuite) newServer(c *gc.C, serverConfig cryptossh.ServerConfig) (*sshServer, cryptossh.PublicKey) {


### PR DESCRIPTION
The function `ParseAuthorisedKey` does not check for new lines in its input. The description above says the function checks "a line from an authorized key file" and the definition for an authorized key in `man sshd` includes the text:
> The optional comment field continues to the end of the line.
Meaning that the comment should not wrap over lines.

A check is added for a newline in the input.

This fixes:
- https://github.com/juju/terraform-provider-juju/issues/363

## QA
Replaced package with local branch in juju 3.3. In go.mod put:
- `replace github.com/juju/utils/v3 => ../utils`
- `go mod tidy`
Ran unit tests for places that use `ParseAuthorizedKey`:
```
go test ./worker/authenticationworker/...
go test ./apiserver/facades/client/keymanager
```

## Other improvements

This PR also fixes some flaky tests by stopping them from using the hosts terminal, and adds a `.gitignore`.
