### PR TITLE
fix: find id_ed25519 key for openssh

### DIFF
--- a/ssh/ssh_openssh.go
+++ b/ssh/ssh_openssh.go
@@ -23,6 +23,7 @@ var defaultIdentities = []string{
 	"~/.ssh/id_rsa",
 	"~/.ssh/id_dsa",
 	"~/.ssh/id_ecdsa",
+	"~/.ssh/id_ed25519",
 }
 
 type opensshCommandKind int


### PR DESCRIPTION
Add id_ed25519 as a default identity for openssh.