### PR TITLE
feat: allow specifying the file to add the keys to and deleting all keys by force

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PROJECT := github.com/juju/utils/v3
 .PHONY: check-licence check-go check
 
 check: check-licence check-go
-	go test -v $(PROJECT)/... -check.vv
+	go test -v $(PROJECT)/... 
 
 check-licence:
 	@(grep -rFl "Licensed under the LGPLv3" .;\

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PROJECT := github.com/juju/utils/v3
 .PHONY: check-licence check-go check
 
 check: check-licence check-go
-	go test $(PROJECT)/...
+	go test -v $(PROJECT)/... -check.v
 
 check-licence:
 	@(grep -rFl "Licensed under the LGPLv3" .;\

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PROJECT := github.com/juju/utils/v3
 .PHONY: check-licence check-go check
 
 check: check-licence check-go
-	go test -v $(PROJECT)/... -check.v
+	go test -v $(PROJECT)/... -check.vv
 
 check-licence:
 	@(grep -rFl "Licensed under the LGPLv3" .;\

--- a/ssh/authorisedkeys.go
+++ b/ssh/authorisedkeys.go
@@ -102,12 +102,12 @@ func SplitAuthorisedKeys(keyData string) []string {
 	return keys
 }
 
-func readAuthorisedKeys(username string) ([]string, error) {
+func readAuthorisedKeys(username, filename string) ([]string, error) {
 	keyDir, err := authKeysDir(username)
 	if err != nil {
 		return nil, err
 	}
-	sshKeyFile := filepath.Join(keyDir, authKeysFile)
+	sshKeyFile := filepath.Join(keyDir, filename)
 	logger.Debugf("reading authorised keys file %s", sshKeyFile)
 	keyData, err := ioutil.ReadFile(sshKeyFile)
 	if os.IsNotExist(err) {
@@ -126,7 +126,7 @@ func readAuthorisedKeys(username string) ([]string, error) {
 	return keys, nil
 }
 
-func writeAuthorisedKeys(username string, keys []string) error {
+func writeAuthorisedKeys(username, filename string, keys []string) error {
 	keyDir, err := authKeysDir(username)
 	if err != nil {
 		return err
@@ -138,7 +138,7 @@ func writeAuthorisedKeys(username string, keys []string) error {
 	keyData := strings.Join(keys, "\n") + "\n"
 
 	// Get perms to use on auth keys file
-	sshKeyFile := filepath.Join(keyDir, authKeysFile)
+	sshKeyFile := filepath.Join(keyDir, filename)
 	perms := os.FileMode(0644)
 	info, err := os.Stat(sshKeyFile)
 	if err == nil {
@@ -193,7 +193,7 @@ var keysMutex sync.Mutex
 func AddKeys(user string, newKeys ...string) error {
 	keysMutex.Lock()
 	defer keysMutex.Unlock()
-	existingKeys, err := readAuthorisedKeys(user)
+	existingKeys, err := readAuthorisedKeys(user, authKeysFile)
 	if err != nil {
 		return err
 	}
@@ -223,7 +223,7 @@ func AddKeys(user string, newKeys ...string) error {
 		}
 	}
 	sshKeys := append(existingKeys, newKeys...)
-	return writeAuthorisedKeys(user, sshKeys)
+	return writeAuthorisedKeys(user, authKeysFile, sshKeys)
 }
 
 // DeleteKeys removes the specified ssh keys from the authorized ssh keys file for user.
@@ -232,7 +232,7 @@ func AddKeys(user string, newKeys ...string) error {
 func DeleteKeys(user string, keyIds ...string) error {
 	keysMutex.Lock()
 	defer keysMutex.Unlock()
-	existingKeyData, err := readAuthorisedKeys(user)
+	existingKeyData, err := readAuthorisedKeys(user, authKeysFile)
 	if err != nil {
 		return err
 	}
@@ -273,7 +273,7 @@ func DeleteKeys(user string, keyIds ...string) error {
 	if len(keysToWrite) == 0 {
 		return errors.Errorf("cannot delete all keys")
 	}
-	return writeAuthorisedKeys(user, keysToWrite)
+	return writeAuthorisedKeys(user, authKeysFile, keysToWrite)
 }
 
 // ReplaceKeys writes the specified ssh keys to the authorized_keys file for user,
@@ -283,7 +283,7 @@ func ReplaceKeys(user string, newKeys ...string) error {
 	keysMutex.Lock()
 	defer keysMutex.Unlock()
 
-	existingKeyData, err := readAuthorisedKeys(user)
+	existingKeyData, err := readAuthorisedKeys(user, authKeysFile)
 	if err != nil {
 		return err
 	}
@@ -294,14 +294,14 @@ func ReplaceKeys(user string, newKeys ...string) error {
 			existingNonKeyLines = append(existingNonKeyLines, line)
 		}
 	}
-	return writeAuthorisedKeys(user, append(existingNonKeyLines, newKeys...))
+	return writeAuthorisedKeys(user, authKeysFile, append(existingNonKeyLines, newKeys...))
 }
 
 // ListKeys returns either the full keys or key comments from the authorized ssh keys file for user.
 func ListKeys(user string, mode ListMode) ([]string, error) {
 	keysMutex.Lock()
 	defer keysMutex.Unlock()
-	keyData, err := readAuthorisedKeys(user)
+	keyData, err := readAuthorisedKeys(user, authKeysFile)
 	if err != nil {
 		return nil, err
 	}
@@ -350,4 +350,122 @@ func EnsureJujuComment(key string) string {
 		}
 	}
 	return key
+}
+
+// AddKeysToFile adds the specified ssh keys to the specified file for user.
+// Returns an error if there is an issue with *any* of the supplied keys.
+func AddKeysToFile(user, file string, newKeys []string) error {
+	keysMutex.Lock()
+	defer keysMutex.Unlock()
+	existingKeys, err := readAuthorisedKeys(user, file)
+	if err != nil {
+		return err
+	}
+	for _, newKey := range newKeys {
+		fingerprint, comment, err := KeyFingerprint(newKey)
+		if err != nil {
+			return err
+		}
+		if comment == "" {
+			return errors.Errorf("cannot add ssh key without comment")
+		}
+		for _, key := range existingKeys {
+			existingFingerprint, existingComment, err := KeyFingerprint(key)
+			if err != nil {
+				// Only log a warning if the unrecognised key line is not a comment.
+				if key[0] != '#' {
+					logger.Warningf("invalid existing ssh key %q: %v", key, err)
+				}
+				continue
+			}
+			if existingFingerprint == fingerprint {
+				return errors.Errorf("cannot add duplicate ssh key: %v", fingerprint)
+			}
+			if existingComment == comment {
+				return errors.Errorf("cannot add ssh key with duplicate comment: %v", comment)
+			}
+		}
+	}
+	sshKeys := append(existingKeys, newKeys...)
+	return writeAuthorisedKeys(user, file, sshKeys)
+}
+
+// DeleteKeysFromFile removes the specified ssh keys from the authorized ssh keys file for user.
+// keyIds may be either key comments or fingerprints.
+// Returns an error if there is an issue with *any* of the keys to delete.
+//
+// Unlike DeleteKeys, this version can delete ALL keys from the target file.
+func DeleteKeysFromFile(user, file string, keyIds []string) error {
+	keysMutex.Lock()
+	defer keysMutex.Unlock()
+	existingKeyData, err := readAuthorisedKeys(user, file)
+	if err != nil {
+		return err
+	}
+	// Build up a map of keys indexed by fingerprint, and fingerprints indexed by comment
+	// so we can easily get the key represented by each keyId, which may be either a fingerprint
+	// or comment.
+	var keysToWrite []string
+	var sshKeys = make(map[string]string)
+	var keyComments = make(map[string]string)
+	for _, key := range existingKeyData {
+		fingerprint, comment, err := KeyFingerprint(key)
+		if err != nil {
+			logger.Debugf("keeping unrecognised existing ssh key %q: %v", key, err)
+			keysToWrite = append(keysToWrite, key)
+			continue
+		}
+		sshKeys[fingerprint] = key
+		if comment != "" {
+			keyComments[comment] = fingerprint
+		}
+	}
+	for _, keyId := range keyIds {
+		// assume keyId may be a fingerprint
+		fingerprint := keyId
+		_, ok := sshKeys[keyId]
+		if !ok {
+			// keyId is a comment
+			fingerprint, ok = keyComments[keyId]
+		}
+		if !ok {
+			return errors.Errorf("cannot delete non existent key: %v", keyId)
+		}
+		delete(sshKeys, fingerprint)
+	}
+	for _, key := range sshKeys {
+		keysToWrite = append(keysToWrite, key)
+	}
+	return writeAuthorisedKeys(user, file, keysToWrite)
+}
+
+// ListKeys returns either the full keys or key comments from the authorized ssh keys file for user.
+func ListKeysFromFile(user, file string, mode ListMode) ([]string, error) {
+	keysMutex.Lock()
+	defer keysMutex.Unlock()
+	keyData, err := readAuthorisedKeys(user, file)
+	if err != nil {
+		return nil, err
+	}
+	var keys []string
+	for _, key := range keyData {
+		fingerprint, comment, err := KeyFingerprint(key)
+		if err != nil {
+			// Only log a warning if the unrecognised key line is not a comment.
+			if key[0] != '#' {
+				logger.Warningf("ignoring invalid ssh key %q: %v", key, err)
+			}
+			continue
+		}
+		if mode == FullKeys {
+			keys = append(keys, key)
+		} else {
+			shortKey := fingerprint
+			if comment != "" {
+				shortKey += fmt.Sprintf(" (%s)", comment)
+			}
+			keys = append(keys, shortKey)
+		}
+	}
+	return keys, nil
 }

--- a/ssh/authorisedkeys.go
+++ b/ssh/authorisedkeys.go
@@ -30,7 +30,7 @@ var (
 )
 
 const (
-	authKeysFile = "authorized_keys"
+	defaultAuthKeysFile = "authorized_keys"
 )
 
 type AuthorisedKey struct {
@@ -193,11 +193,11 @@ var keysMutex sync.Mutex
 func AddKeys(user string, newKeys ...string) error {
 	keysMutex.Lock()
 	defer keysMutex.Unlock()
-	existingKeys, err := readAuthorisedKeys(user, authKeysFile)
+	existingKeys, err := readAuthorisedKeys(user, defaultAuthKeysFile)
 	if err != nil {
 		return err
 	}
-	return addKeys(user, authKeysFile, newKeys, existingKeys)
+	return addKeys(user, defaultAuthKeysFile, newKeys, existingKeys)
 }
 
 // DeleteKeys removes the specified ssh keys from the authorized ssh keys file for user.
@@ -206,11 +206,11 @@ func AddKeys(user string, newKeys ...string) error {
 func DeleteKeys(user string, keyIds ...string) error {
 	keysMutex.Lock()
 	defer keysMutex.Unlock()
-	existingKeys, err := readAuthorisedKeys(user, authKeysFile)
+	existingKeys, err := readAuthorisedKeys(user, defaultAuthKeysFile)
 	if err != nil {
 		return err
 	}
-	return deleteKeys(user, authKeysFile, existingKeys, keyIds, false)
+	return deleteKeys(user, defaultAuthKeysFile, existingKeys, keyIds, false)
 }
 
 // ReplaceKeys writes the specified ssh keys to the authorized_keys file for user,
@@ -220,7 +220,7 @@ func ReplaceKeys(user string, newKeys ...string) error {
 	keysMutex.Lock()
 	defer keysMutex.Unlock()
 
-	existingKeyData, err := readAuthorisedKeys(user, authKeysFile)
+	existingKeyData, err := readAuthorisedKeys(user, defaultAuthKeysFile)
 	if err != nil {
 		return err
 	}
@@ -231,14 +231,14 @@ func ReplaceKeys(user string, newKeys ...string) error {
 			existingNonKeyLines = append(existingNonKeyLines, line)
 		}
 	}
-	return writeAuthorisedKeys(user, authKeysFile, append(existingNonKeyLines, newKeys...))
+	return writeAuthorisedKeys(user, defaultAuthKeysFile, append(existingNonKeyLines, newKeys...))
 }
 
 // ListKeys returns either the full keys or key comments from the authorized ssh keys file for user.
 func ListKeys(user string, mode ListMode) ([]string, error) {
 	keysMutex.Lock()
 	defer keysMutex.Unlock()
-	keyData, err := readAuthorisedKeys(user, authKeysFile)
+	keyData, err := readAuthorisedKeys(user, defaultAuthKeysFile)
 	if err != nil {
 		return nil, err
 	}

--- a/ssh/authorisedkeys_test.go
+++ b/ssh/authorisedkeys_test.go
@@ -29,8 +29,8 @@ const (
 
 var _ = gc.Suite(&AuthorisedKeysKeysSuite{})
 
-func writeAuthKeysFile(c *gc.C, keys []string) {
-	err := ssh.WriteAuthorisedKeys(testSSHUser, authKeysFile, keys)
+func writeAuthKeysFile(c *gc.C, keys []string, file string) {
+	err := ssh.WriteAuthorisedKeys(testSSHUser, file, keys)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -39,7 +39,7 @@ func (s *AuthorisedKeysKeysSuite) TestListKeys(c *gc.C) {
 		sshtesting.ValidKeyOne.Key + " user@host",
 		sshtesting.ValidKeyTwo.Key,
 	}
-	writeAuthKeysFile(c, keys)
+	writeAuthKeysFile(c, keys, authKeysFile)
 	keys, err := ssh.ListKeys(testSSHUser, ssh.Fingerprints)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(
@@ -52,7 +52,7 @@ func (s *AuthorisedKeysKeysSuite) TestListKeysFull(c *gc.C) {
 		sshtesting.ValidKeyOne.Key + " user@host",
 		sshtesting.ValidKeyTwo.Key + " anotheruser@host",
 	}
-	writeAuthKeysFile(c, keys)
+	writeAuthKeysFile(c, keys, authKeysFile)
 	actual, err := ssh.ListKeys(testSSHUser, ssh.FullKeys)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(actual, gc.DeepEquals, keys)
@@ -69,7 +69,7 @@ func (s *AuthorisedKeysKeysSuite) TestAddNewKey(c *gc.C) {
 
 func (s *AuthorisedKeysKeysSuite) TestAddMoreKeys(c *gc.C) {
 	firstKey := sshtesting.ValidKeyOne.Key + " user@host"
-	writeAuthKeysFile(c, []string{firstKey})
+	writeAuthKeysFile(c, []string{firstKey}, authKeysFile)
 	moreKeys := []string{
 		sshtesting.ValidKeyTwo.Key + " anotheruser@host",
 		sshtesting.ValidKeyThree.Key + " yetanotheruser@host",
@@ -115,7 +115,7 @@ func (s *AuthorisedKeysKeysSuite) TestAddKeyWithoutComment(c *gc.C) {
 }
 
 func (s *AuthorisedKeysKeysSuite) TestAddKeepsUnrecognised(c *gc.C) {
-	writeAuthKeysFile(c, []string{sshtesting.ValidKeyOne.Key, "invalid-key"})
+	writeAuthKeysFile(c, []string{sshtesting.ValidKeyOne.Key, "invalid-key"}, authKeysFile)
 	anotherKey := sshtesting.ValidKeyTwo.Key + " anotheruser@host"
 	err := ssh.AddKeys(testSSHUser, anotherKey)
 	c.Assert(err, jc.ErrorIsNil)
@@ -128,7 +128,7 @@ func (s *AuthorisedKeysKeysSuite) TestDeleteKeys(c *gc.C) {
 	firstKey := sshtesting.ValidKeyOne.Key + " user@host"
 	anotherKey := sshtesting.ValidKeyTwo.Key
 	thirdKey := sshtesting.ValidKeyThree.Key + " anotheruser@host"
-	writeAuthKeysFile(c, []string{firstKey, anotherKey, thirdKey})
+	writeAuthKeysFile(c, []string{firstKey, anotherKey, thirdKey}, authKeysFile)
 	err := ssh.DeleteKeys(testSSHUser, "user@host", sshtesting.ValidKeyTwo.Fingerprint)
 	c.Assert(err, jc.ErrorIsNil)
 	actual, err := ssh.ListKeys(testSSHUser, ssh.FullKeys)
@@ -138,7 +138,7 @@ func (s *AuthorisedKeysKeysSuite) TestDeleteKeys(c *gc.C) {
 
 func (s *AuthorisedKeysKeysSuite) TestDeleteKeysKeepsUnrecognised(c *gc.C) {
 	firstKey := sshtesting.ValidKeyOne.Key + " user@host"
-	writeAuthKeysFile(c, []string{firstKey, sshtesting.ValidKeyTwo.Key, "invalid-key"})
+	writeAuthKeysFile(c, []string{firstKey, sshtesting.ValidKeyTwo.Key, "invalid-key"}, authKeysFile)
 	err := ssh.DeleteKeys(testSSHUser, "user@host")
 	c.Assert(err, jc.ErrorIsNil)
 	actual, err := ssh.ReadAuthorisedKeys(testSSHUser, authKeysFile)
@@ -148,14 +148,14 @@ func (s *AuthorisedKeysKeysSuite) TestDeleteKeysKeepsUnrecognised(c *gc.C) {
 
 func (s *AuthorisedKeysKeysSuite) TestDeleteNonExistentComment(c *gc.C) {
 	firstKey := sshtesting.ValidKeyOne.Key + " user@host"
-	writeAuthKeysFile(c, []string{firstKey})
+	writeAuthKeysFile(c, []string{firstKey}, authKeysFile)
 	err := ssh.DeleteKeys(testSSHUser, "someone@host")
 	c.Assert(err, gc.ErrorMatches, "cannot delete non existent key: someone@host")
 }
 
 func (s *AuthorisedKeysKeysSuite) TestDeleteNonExistentFingerprint(c *gc.C) {
 	firstKey := sshtesting.ValidKeyOne.Key + " user@host"
-	writeAuthKeysFile(c, []string{firstKey})
+	writeAuthKeysFile(c, []string{firstKey}, authKeysFile)
 	err := ssh.DeleteKeys(testSSHUser, sshtesting.ValidKeyTwo.Fingerprint)
 	c.Assert(err, gc.ErrorMatches, "cannot delete non existent key: "+sshtesting.ValidKeyTwo.Fingerprint)
 }
@@ -165,7 +165,7 @@ func (s *AuthorisedKeysKeysSuite) TestDeleteLastKeyForbidden(c *gc.C) {
 		sshtesting.ValidKeyOne.Key + " user@host",
 		sshtesting.ValidKeyTwo.Key + " yetanotheruser@host",
 	}
-	writeAuthKeysFile(c, keys)
+	writeAuthKeysFile(c, keys, authKeysFile)
 	err := ssh.DeleteKeys(testSSHUser, "user@host", sshtesting.ValidKeyTwo.Fingerprint)
 	c.Assert(err, gc.ErrorMatches, "cannot delete all keys")
 }
@@ -173,7 +173,7 @@ func (s *AuthorisedKeysKeysSuite) TestDeleteLastKeyForbidden(c *gc.C) {
 func (s *AuthorisedKeysKeysSuite) TestReplaceKeys(c *gc.C) {
 	firstKey := sshtesting.ValidKeyOne.Key + " user@host"
 	anotherKey := sshtesting.ValidKeyTwo.Key
-	writeAuthKeysFile(c, []string{firstKey, anotherKey})
+	writeAuthKeysFile(c, []string{firstKey, anotherKey}, authKeysFile)
 
 	// replaceKey is created without a comment so test that
 	// ReplaceKeys handles keys without comments. This is
@@ -189,7 +189,7 @@ func (s *AuthorisedKeysKeysSuite) TestReplaceKeys(c *gc.C) {
 }
 
 func (s *AuthorisedKeysKeysSuite) TestReplaceKeepsUnrecognised(c *gc.C) {
-	writeAuthKeysFile(c, []string{sshtesting.ValidKeyOne.Key, "invalid-key"})
+	writeAuthKeysFile(c, []string{sshtesting.ValidKeyOne.Key, "invalid-key"}, authKeysFile)
 	anotherKey := sshtesting.ValidKeyTwo.Key + " anotheruser@host"
 	err := ssh.ReplaceKeys(testSSHUser, anotherKey)
 	c.Assert(err, jc.ErrorIsNil)
@@ -291,7 +291,7 @@ func (s *AuthorisedKeysKeysSuite) TestConcatAuthorisedKeys(c *gc.C) {
 	}
 }
 
-func (s *AuthorisedKeysKeysSuite) TestAddKeysToFile(c *gc.C) {
+func (s *AuthorisedKeysKeysSuite) TestAddKeysToFileToDifferentFiles(c *gc.C) {
 	key1 := sshtesting.ValidKeyOne.Key + " user@host"
 	err := ssh.AddKeysToFile(testSSHUser, alternativeKeysFile2, []string{key1})
 	c.Assert(err, jc.ErrorIsNil)
@@ -309,20 +309,40 @@ func (s *AuthorisedKeysKeysSuite) TestAddKeysToFile(c *gc.C) {
 	c.Assert(list2, gc.DeepEquals, []string{key2})
 }
 
-func (s *AuthorisedKeysKeysSuite) TestDeleteKeysFromFile(c *gc.C) {
+func (s *AuthorisedKeysKeysSuite) TestAddKeysToFileMultipleKeys(c *gc.C) {
 	key1 := sshtesting.ValidKeyOne.Key + " user@host"
-	err := ssh.AddKeysToFile(testSSHUser, alternativeKeysFile2, []string{key1})
+	key2 := sshtesting.ValidKeyTwo.Key + " alice@host"
+	err := ssh.AddKeysToFile(testSSHUser, alternativeKeysFile2, []string{key1, key2})
 	c.Assert(err, jc.ErrorIsNil)
 
-	list1, err := ssh.ListKeysFromFile(testSSHUser, alternativeKeysFile2, ssh.FullKeys)
+	list, err := ssh.ListKeysFromFile(testSSHUser, alternativeKeysFile2, ssh.FullKeys)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(list1, gc.DeepEquals, []string{key1})
+	c.Assert(list, jc.DeepEquals, []string{key1, key2})
+}
 
-	err = ssh.DeleteKeysFromFile(testSSHUser, alternativeKeysFile2, []string{sshtesting.ValidKeyOne.Fingerprint})
+func (s *AuthorisedKeysKeysSuite) TestDeleteAllKeysFromFile(c *gc.C) {
+	key1 := sshtesting.ValidKeyOne.Key + " user@host"
+	writeAuthKeysFile(c, []string{key1}, alternativeKeysFile2)
+
+	err := ssh.DeleteKeysFromFile(testSSHUser, alternativeKeysFile2, []string{sshtesting.ValidKeyOne.Fingerprint})
 	c.Assert(err, jc.ErrorIsNil)
 
 	emptyList, err := ssh.ListKeysFromFile(testSSHUser, alternativeKeysFile2, ssh.FullKeys)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(emptyList, gc.DeepEquals, []string(nil))
+	c.Assert(emptyList, gc.HasLen, 0)
+}
 
+func (s *AuthorisedKeysKeysSuite) TestDeleteSomeKeysFromFile(c *gc.C) {
+	key1 := sshtesting.ValidKeyOne.Key + " user@host"
+	key2 := sshtesting.ValidKeyTwo.Key + " alice@host"
+	key3 := sshtesting.ValidKeyThree.Key + " bob@host"
+	writeAuthKeysFile(c, []string{key1, key2, key3}, alternativeKeysFile2)
+
+	err := ssh.DeleteKeysFromFile(testSSHUser, alternativeKeysFile2, []string{sshtesting.ValidKeyTwo.Fingerprint})
+	c.Assert(err, jc.ErrorIsNil)
+
+	keys, err := ssh.ListKeysFromFile(testSSHUser, alternativeKeysFile2, ssh.FullKeys)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(keys, gc.HasLen, 2)
+	c.Assert(keys, jc.DeepEquals, []string{key1, key3})
 }

--- a/ssh/authorisedkeys_test.go
+++ b/ssh/authorisedkeys_test.go
@@ -344,5 +344,5 @@ func (s *AuthorisedKeysKeysSuite) TestDeleteSomeKeysFromFile(c *gc.C) {
 	keys, err := ssh.ListKeysFromFile(testSSHUser, alternativeKeysFile2, ssh.FullKeys)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(keys, gc.HasLen, 2)
-	c.Assert(keys, jc.DeepEquals, []string{key1, key3})
+	c.Assert(keys, jc.SameContents, []string{key1, key3})
 }


### PR DESCRIPTION
To enable the sshsession worker work for the SSH proxy, we need to write authorized_keys to a separate file other than the default one that juju uses. This allows us to keep Juju working as is and also enable the new way of SSHing, ensuring that they do not conflict with each other. We also need to allow the deletion of ALL kets within a file, and this is guarded by a force flag that will only be used from the sshsession worker.

